### PR TITLE
feat(forms-angular): implement Phase 4 domain UI components with layout integration

### DIFF
--- a/libs/forms/angular/README.md
+++ b/libs/forms/angular/README.md
@@ -1,6 +1,6 @@
 # @anarchitects/forms-angular
 
-Angular bricks for consuming the Anarchitecture Forms platform. This package wires together
+Angular domain UI components for consuming the Anarchitecture Forms platform. This package wires together
 configuration, data-access, state, feature, and UI layers so Angular applications can request
 contract-driven form definitions, render them dynamically, and submit responses.
 
@@ -14,8 +14,8 @@ layer in the 3-tier architecture:
 | `@anarchitects/forms-angular/config`      | Injection tokens and provider helpers for base API configuration.          |
 | `@anarchitects/forms-angular/data-access` | HTTP adapters that call the generated forms REST API.                      |
 | `@anarchitects/forms-angular/state`       | Signal store that orchestrates requests, caching, and submission state.    |
-| `@anarchitects/forms-angular/feature`     | Feature component that combines state, UI, and orchestration.              |
-| `@anarchitects/forms-angular/ui`          | Presentational form renderer that builds reactive forms from form configs. |
+| `@anarchitects/forms-angular/feature`     | Feature components that combine state, UI, and orchestration.              |
+| `@anarchitects/forms-angular/ui`          | Presentational form/list/detail components with layout/template contracts. |
 
 Each layer can be consumed independently or as a combined stack, depending on what your app needs.
 
@@ -73,7 +73,8 @@ You can opt into specific slices of the stack:
   with custom facades or state.
 - **State** – inject the `FormsStore` signal store to orchestrate requests and expose reactive signals
   for loading/error/submission status.
-- **UI** – use `AnarchitectsUiForm` directly if you manage fetching and submission elsewhere.
+- **UI** – use `AnarchitectsUiForm`, `AnarchitectsFormsUiSubmissionList`, and
+  `AnarchitectsFormsUiSubmissionDetail` directly if you manage orchestration elsewhere.
 
 ## Publishing
 

--- a/libs/forms/angular/feature/README.md
+++ b/libs/forms/angular/feature/README.md
@@ -1,8 +1,12 @@
 # @anarchitects/forms-angular/feature
 
 Feature-level orchestration for the forms Angular stack. Import components such as
-`AnarchitectsFeatureForm` from this entry point to combine the signal store, data access, and UI
-layers into a drop-in experience.
+`AnarchitectsFeatureForm`, `AnarchitectsFeatureSubmissionList`, and
+`AnarchitectsFeatureSubmissionDetail` from this entry point to combine the signal store,
+data access, and UI layers into a drop-in experience.
+
+These components remain layout-compatible and forward canonical template/slot hooks to
+the underlying UI layer.
 
 ## License
 

--- a/libs/forms/angular/feature/src/form.html
+++ b/libs/forms/angular/feature/src/form.html
@@ -5,6 +5,11 @@
 } @else {
 <anarchitects-forms-ui-form
   [config]="formConfig()"
+  [layout]="layout()"
+  [layoutOptions]="layoutOptions()"
   (submitted)="submitForm($event)"
-/>
+>
+  <ng-content select="ng-template[anxTemplate]"></ng-content>
+  <ng-content select="[anxSlot]"></ng-content>
+</anarchitects-forms-ui-form>
 }

--- a/libs/forms/angular/feature/src/form.stories.ts
+++ b/libs/forms/angular/feature/src/form.stories.ts
@@ -108,6 +108,17 @@ export const Primary: Story = {
   },
 };
 
+export const CardLayout: Story = {
+  args: {
+    formId: formId,
+    formVersion: formVersion,
+    layout: 'form:card',
+  },
+  parameters: {
+    mockData: [getFormDefinitionMock],
+  },
+};
+
 export const InvalidEmailKeepsFormInvalid: Story = {
   args: {
     formId: formId,

--- a/libs/forms/angular/feature/src/form.ts
+++ b/libs/forms/angular/feature/src/form.ts
@@ -8,6 +8,7 @@ import {
 } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { FormConfig } from '@anarchitects/forms-ts/models';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -31,6 +32,8 @@ export class AnarchitectsFeatureForm {
   formConfig = signal<FormConfig>({ id: '', version: 1, fields: [] });
   formId = input.required<string>();
   formVersion = input<number>();
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
 
   constructor() {
     effect(() => {

--- a/libs/forms/angular/feature/src/index.ts
+++ b/libs/forms/angular/feature/src/index.ts
@@ -1,1 +1,3 @@
 export * from './form';
+export * from './submission-list';
+export * from './submission-detail';

--- a/libs/forms/angular/feature/src/submission-detail.css
+++ b/libs/forms/angular/feature/src/submission-detail.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/libs/forms/angular/feature/src/submission-detail.html
+++ b/libs/forms/angular/feature/src/submission-detail.html
@@ -1,0 +1,9 @@
+<anarchitects-forms-ui-submission-detail
+  [submission]="submission()"
+  [title]="title()"
+  [layout]="layout()"
+  [layoutOptions]="layoutOptions()"
+>
+  <ng-content select="ng-template[anxTemplate]"></ng-content>
+  <ng-content select="[anxSlot]"></ng-content>
+</anarchitects-forms-ui-submission-detail>

--- a/libs/forms/angular/feature/src/submission-detail.spec.ts
+++ b/libs/forms/angular/feature/src/submission-detail.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef, signal } from '@angular/core';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { FormsStore } from '@anarchitects/forms-angular/state';
+import { AnarchitectsFeatureSubmissionDetail } from './submission-detail';
+
+describe('AnarchitectsFeatureSubmissionDetail', () => {
+  let component: AnarchitectsFeatureSubmissionDetail;
+  let fixture: ComponentFixture<AnarchitectsFeatureSubmissionDetail>;
+  let ref: ComponentRef<AnarchitectsFeatureSubmissionDetail>;
+
+  const mockSubmissions = signal<Submission[]>([
+    {
+      id: 'submission-1',
+      formId: 'contact',
+      formVersion: 1,
+      payload: { name: 'Jane Doe' },
+      createdAt: new Date('2026-01-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    },
+    {
+      id: 'submission-2',
+      formId: 'feedback',
+      formVersion: 1,
+      payload: { message: 'Hello' },
+      createdAt: new Date('2026-01-02T10:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T10:00:00.000Z'),
+    },
+  ]);
+
+  const mockFormsStore = {
+    submissionsEntities: mockSubmissions,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnarchitectsFeatureSubmissionDetail],
+    })
+      .overrideComponent(AnarchitectsFeatureSubmissionDetail, {
+        set: {
+          providers: [{ provide: FormsStore, useValue: mockFormsStore }],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AnarchitectsFeatureSubmissionDetail);
+    component = fixture.componentInstance;
+    ref = fixture.componentRef;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should resolve submission by id when provided', () => {
+    ref.setInput('submissionId', 'submission-2');
+    fixture.detectChanges();
+
+    expect(component.submission()?.id).toBe('submission-2');
+  });
+
+  it('should fallback to first submission when no id is provided', () => {
+    expect(component.submission()?.id).toBe('submission-1');
+  });
+});

--- a/libs/forms/angular/feature/src/submission-detail.ts
+++ b/libs/forms/angular/feature/src/submission-detail.ts
@@ -1,0 +1,45 @@
+import {
+  FormsStore,
+  provideFormsState,
+} from '@anarchitects/forms-angular/state';
+import { AnarchitectsFormsUiSubmissionDetail } from '@anarchitects/forms-angular/ui';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+
+@Component({
+  selector: 'anarchitects-forms-feature-submission-detail',
+  imports: [AnarchitectsFormsUiSubmissionDetail],
+  providers: [provideFormsState()],
+  templateUrl: './submission-detail.html',
+  styleUrl: './submission-detail.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'anx-domain-component anx-forms-feature-submission-detail anx-stack',
+    'attr.data-anx-component': '"forms-feature-submission-detail"',
+  },
+})
+export class AnarchitectsFeatureSubmissionDetail {
+  private readonly store = inject(FormsStore);
+
+  readonly submissionId = input<string | null>(null);
+  readonly title = input('Submission details');
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
+
+  readonly submission = computed(() => {
+    const entries = this.store.submissionsEntities();
+    const selectedId = this.submissionId();
+
+    if (selectedId) {
+      return entries.find((entry) => entry.id === selectedId) ?? null;
+    }
+
+    return entries[0] ?? null;
+  });
+}

--- a/libs/forms/angular/feature/src/submission-list.css
+++ b/libs/forms/angular/feature/src/submission-list.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/libs/forms/angular/feature/src/submission-list.html
+++ b/libs/forms/angular/feature/src/submission-list.html
@@ -1,0 +1,10 @@
+<anarchitects-forms-ui-submission-list
+  [submissions]="submissions()"
+  [title]="title()"
+  [layout]="layout()"
+  [layoutOptions]="layoutOptions()"
+  (selected)="onSelected($event)"
+>
+  <ng-content select="ng-template[anxTemplate]"></ng-content>
+  <ng-content select="[anxSlot]"></ng-content>
+</anarchitects-forms-ui-submission-list>

--- a/libs/forms/angular/feature/src/submission-list.spec.ts
+++ b/libs/forms/angular/feature/src/submission-list.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef, signal } from '@angular/core';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { FormsStore } from '@anarchitects/forms-angular/state';
+import { AnarchitectsFeatureSubmissionList } from './submission-list';
+
+describe('AnarchitectsFeatureSubmissionList', () => {
+  let component: AnarchitectsFeatureSubmissionList;
+  let fixture: ComponentFixture<AnarchitectsFeatureSubmissionList>;
+  let ref: ComponentRef<AnarchitectsFeatureSubmissionList>;
+
+  const mockSubmissions = signal<Submission[]>([
+    {
+      id: 'submission-1',
+      formId: 'contact',
+      formVersion: 1,
+      payload: { name: 'Jane Doe' },
+      createdAt: new Date('2026-01-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    },
+    {
+      id: 'submission-2',
+      formId: 'feedback',
+      formVersion: 1,
+      payload: { message: 'Hello' },
+      createdAt: new Date('2026-01-02T10:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T10:00:00.000Z'),
+    },
+  ]);
+
+  const mockFormsStore = {
+    submissionsEntities: mockSubmissions,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnarchitectsFeatureSubmissionList],
+    })
+      .overrideComponent(AnarchitectsFeatureSubmissionList, {
+        set: {
+          providers: [{ provide: FormsStore, useValue: mockFormsStore }],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AnarchitectsFeatureSubmissionList);
+    component = fixture.componentInstance;
+    ref = fixture.componentRef;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should filter submissions by form id when provided', () => {
+    ref.setInput('formId', 'contact');
+    fixture.detectChanges();
+
+    expect(component.submissions()).toHaveLength(1);
+    expect(component.submissions()[0].formId).toBe('contact');
+  });
+
+  it('should emit selected submission from UI event', () => {
+    const emitSpy = jest.spyOn(component.selected, 'emit');
+
+    component.onSelected(mockSubmissions()[0]);
+
+    expect(emitSpy).toHaveBeenCalledWith(mockSubmissions()[0]);
+  });
+});

--- a/libs/forms/angular/feature/src/submission-list.ts
+++ b/libs/forms/angular/feature/src/submission-list.ts
@@ -1,0 +1,55 @@
+import {
+  FormsStore,
+  provideFormsState,
+} from '@anarchitects/forms-angular/state';
+import { AnarchitectsFormsUiSubmissionList } from '@anarchitects/forms-angular/ui';
+import { Submission } from '@anarchitects/forms-ts/models';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+
+@Component({
+  selector: 'anarchitects-forms-feature-submission-list',
+  imports: [AnarchitectsFormsUiSubmissionList],
+  providers: [provideFormsState()],
+  templateUrl: './submission-list.html',
+  styleUrl: './submission-list.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'anx-domain-component anx-forms-feature-submission-list anx-stack',
+    'attr.data-anx-component': '"forms-feature-submission-list"',
+  },
+})
+export class AnarchitectsFeatureSubmissionList {
+  private readonly store = inject(FormsStore);
+
+  readonly formId = input<string | null>(null);
+  readonly title = input('Submissions');
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
+
+  readonly selected = output<Submission>();
+
+  readonly submissions = computed(() => {
+    const scopedFormId = this.formId();
+    const allSubmissions = this.store.submissionsEntities();
+
+    if (!scopedFormId) {
+      return allSubmissions;
+    }
+
+    return allSubmissions.filter(
+      (submission) => submission.formId === scopedFormId,
+    );
+  });
+
+  onSelected(submission: Submission): void {
+    this.selected.emit(submission);
+  }
+}

--- a/libs/forms/angular/package.json
+++ b/libs/forms/angular/package.json
@@ -2,6 +2,9 @@
   "name": "@anarchitects/forms-angular",
   "version": "2.1.0",
   "peerDependencies": {
+    "@anarchitects/common-angular-ui-composition": "^0.0.1",
+    "@anarchitects/common-angular-ui-layouts": "^0.0.1",
+    "@anarchitects/common-angular-ui-primitives": "^0.0.1",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
     "@ngrx/signals": "^20.0.1",

--- a/libs/forms/angular/ui/README.md
+++ b/libs/forms/angular/ui/README.md
@@ -1,7 +1,16 @@
 # @anarchitects/forms-angular/ui
 
-Presentational components for `@anarchitects/forms-angular`. Import `AnarchitectsUiForm` from this
-entry point to render reactive forms based on contract-driven form configurations.
+Presentational domain UI components for `@anarchitects/forms-angular`.
+
+## Exports
+
+- `AnarchitectsUiForm`
+- `AnarchitectsFormsUiSubmitted`
+- `AnarchitectsFormsUiSubmissionList`
+- `AnarchitectsFormsUiSubmissionDetail`
+
+These components are layout-compatible (`anarchitects-ui-layout-host`) and support
+template overrides via canonical `ng-template[anxTemplate]` contracts.
 
 ## License
 

--- a/libs/forms/angular/ui/src/form.css
+++ b/libs/forms/angular/ui/src/form.css
@@ -1,3 +1,21 @@
 :host {
   display: block;
 }
+
+.anx-forms-ui-form__surface {
+  width: 100%;
+}
+
+.anx-forms-ui-form__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--anx-sys-space-xs);
+}
+
+.anx-forms-ui-form__honeypot {
+  position: absolute;
+  inline-size: 0;
+  block-size: 0;
+  opacity: 0;
+  pointer-events: none;
+}

--- a/libs/forms/angular/ui/src/form.html
+++ b/libs/forms/angular/ui/src/form.html
@@ -1,45 +1,103 @@
-@if (config()) {
-<form (ngSubmit)="onSubmit()" [formGroup]="formGroup">
-  @for (f of config().fields; track f.name) {
-  <div class="form-group">
-    @if (f.ui?.label) {
-    <label for="{{ f.name }}">{{ f.ui!.label }}</label>
-    } @if (f.kind === 'string' || f.kind === 'email' || f.kind === 'password') {
+<form
+  class="anx-forms-ui-form__surface anx-stack"
+  (ngSubmit)="onSubmit()"
+  [formGroup]="formGroup"
+>
+  <anarchitects-ui-layout-host
+    [kind]="'form'"
+    [layout]="layout()"
+    [model]="layoutModel()"
+    [layoutOptions]="layoutOptions()"
+  >
+    <ng-content select="ng-template[anxTemplate]"></ng-content>
+    <ng-content select="[anxSlot]"></ng-content>
+
+    <ng-template anxTemplate="field" let-field let-index="index">
+      <anarchitects-ui-field
+        [forId]="fieldId(field.name)"
+        [required]="!!field.required"
+        [invalid]="isFieldInvalid(field.name)"
+      >
+        <span anxSlot="label">{{ field.ui?.label ?? field.name }}</span>
+
+        @switch (field.kind) {
+          @case ('textarea') {
+            <textarea
+              anxSlot="content"
+              anarchitectsUiTextarea
+              [id]="fieldId(field.name)"
+              [formControlName]="field.name"
+              [rows]="field.ui?.rows ?? 4"
+              [placeholder]="field.ui?.placeholder ?? ''"
+              [invalid]="isFieldInvalid(field.name)"
+            ></textarea>
+          }
+          @case ('select') {
+            <select
+              anxSlot="content"
+              anarchitectsUiSelect
+              [id]="fieldId(field.name)"
+              [formControlName]="field.name"
+              [invalid]="isFieldInvalid(field.name)"
+            >
+              @for (option of field.options ?? []; track option.value) {
+                <option [value]="option.value">{{ option.label }}</option>
+              }
+            </select>
+          }
+          @case ('boolean') {
+            <label anxSlot="content" class="anx-forms-ui-form__checkbox">
+              <input
+                type="checkbox"
+                [id]="fieldId(field.name)"
+                [formControlName]="field.name"
+              />
+              <span>{{ field.ui?.placeholder ?? 'Enabled' }}</span>
+            </label>
+          }
+          @default {
+            <input
+              anxSlot="content"
+              anarchitectsUiInput
+              [attr.type]="
+                field.kind === 'email'
+                  ? 'email'
+                  : field.kind === 'password'
+                    ? 'password'
+                    : 'text'
+              "
+              [id]="fieldId(field.name)"
+              [formControlName]="field.name"
+              [placeholder]="field.ui?.placeholder ?? ''"
+              [invalid]="isFieldInvalid(field.name)"
+            />
+          }
+        }
+
+        @if (field.ui?.help; as helpText) {
+          <span anxSlot="hint">{{ helpText }}</span>
+        }
+
+        @if (fieldErrorMessage(field.name); as errorText) {
+          <span anxSlot="error">{{ errorText }}</span>
+        }
+      </anarchitects-ui-field>
+    </ng-template>
+
+    <ng-template anxTemplate="actions">
+      <anarchitects-ui-button [type]="'submit'" [disabled]="formGroup.invalid">
+        Submit
+      </anarchitects-ui-button>
+    </ng-template>
+  </anarchitects-ui-layout-host>
+
+  @if (config().security?.honeypot) {
     <input
-      [attr.type]="
-        f.kind === 'email' ? 'email' : f.kind === 'password' ? 'password' : 'text'
-      "
-      [id]="f.name"
-      [formControlName]="f.name"
-      [placeholder]="f.ui?.placeholder"
+      class="anx-forms-ui-form__honeypot"
+      type="text"
+      [name]="config().security!.honeypot"
+      autocomplete="off"
+      tabindex="-1"
     />
-    } @else if (f.kind === 'textarea') {
-    <textarea
-      [id]="f.name"
-      [formControlName]="f.name"
-      [rows]="f.ui?.rows ?? 4"
-      [placeholder]="f.ui?.placeholder"
-    ></textarea>
-    } @else if (f.kind === 'boolean') {
-    <input type="checkbox" [id]="f.name" [formControlName]="f.name" /><span
-      >{{ f.ui?.placeholder }}</span
-    >
-    } @else if (f.kind === 'select' && f.options) {
-    <select [id]="f.name" [formControlName]="f.name">
-      @for (option of f.options; track option.value) {
-      <option [value]="option.value">{{ option.label }}</option>
-      }
-    </select>
-    }
-  </div>
-  } @if (config().security?.honeypot) {
-  <input
-    type="text"
-    [name]="config().security!.honeypot"
-    style="display: none"
-    autocomplete="off"
-  />
   }
-  <button type="submit" [disabled]="formGroup.invalid">Submit</button>
 </form>
-}

--- a/libs/forms/angular/ui/src/form.stories.ts
+++ b/libs/forms/angular/ui/src/form.stories.ts
@@ -1,11 +1,18 @@
 import { FormConfig } from '@anarchitects/forms-ts';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { moduleMetadata } from '@storybook/angular';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import { AnarchitectsUiForm } from './form';
 
 const meta: Meta<AnarchitectsUiForm> = {
   component: AnarchitectsUiForm,
-  title: 'AnarchitectsUiForm',
+  title: 'Forms UI/Form',
+  decorators: [
+    moduleMetadata({
+      imports: [AnxTemplateDirective],
+    }),
+  ],
 };
 export default meta;
 
@@ -70,6 +77,34 @@ export const Primary: Story = {
     const submitButton = await canvas.findByRole('button', { name: /submit/i });
     expect((submitButton as HTMLButtonElement).disabled).toBe(true);
   },
+};
+
+export const GridLayout: Story = {
+  args: {
+    config: mockFormConfig,
+    layout: 'form:grid',
+    layoutOptions: { columns: 2 },
+  },
+};
+
+export const TemplateOverride: Story = {
+  args: {
+    config: mockFormConfig,
+    layout: 'form:stacked',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <anarchitects-forms-ui-form [config]="config" [layout]="layout">
+        <ng-template anxTemplate="field" let-field>
+          <section class="anx-stack" style="gap: .25rem;">
+            <strong>Custom field template: {{ field.ui?.label ?? field.name }}</strong>
+            <span>Render your own control composition here.</span>
+          </section>
+        </ng-template>
+      </anarchitects-forms-ui-form>
+    `,
+  }),
 };
 
 export const InvalidEmailKeepsFormInvalid: Story = {

--- a/libs/forms/angular/ui/src/form.ts
+++ b/libs/forms/angular/ui/src/form.ts
@@ -1,27 +1,64 @@
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { FormConfig } from '@anarchitects/forms-ts/models';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   input,
   output,
 } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AnarchitectsUiButton } from '@anarchitects/common-angular-ui-primitives/actions';
+import {
+  AnarchitectsUiField,
+  AnarchitectsUiInputDirective,
+  AnarchitectsUiSelectDirective,
+  AnarchitectsUiTextareaDirective,
+} from '@anarchitects/common-angular-ui-primitives/form-controls';
+import { AnxSlotDirective } from '@anarchitects/common-angular-ui-composition/projection';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { provideAnxDefaultLayouts } from '@anarchitects/common-angular-ui-layouts/defaults';
+import { AnarchitectsUiLayoutHost } from '@anarchitects/common-angular-ui-layouts/host';
 
 @Component({
   selector: 'anarchitects-forms-ui-form',
-  imports: [ReactiveFormsModule],
+  imports: [
+    ReactiveFormsModule,
+    NgTemplateOutlet,
+    AnarchitectsUiLayoutHost,
+    AnarchitectsUiField,
+    AnarchitectsUiButton,
+    AnarchitectsUiInputDirective,
+    AnarchitectsUiTextareaDirective,
+    AnarchitectsUiSelectDirective,
+    AnxSlotDirective,
+    AnxTemplateDirective,
+  ],
+  providers: [provideAnxDefaultLayouts()],
   templateUrl: './form.html',
   styleUrl: './form.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'anx-domain-component anx-forms-ui-form anx-stack',
+    'attr.data-anx-component': '"forms-ui-form"',
+  },
 })
 export class AnarchitectsUiForm {
   private readonly fb = inject(FormBuilder);
   readonly formGroup = this.fb.group({});
   readonly config = input.required<FormConfig>();
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<SubmissionRequestDTO>();
+
+  readonly layoutModel = computed(() => ({
+    title: this.config().id,
+    fields: this.config().fields,
+  }));
 
   constructor() {
     effect(() => {
@@ -49,6 +86,42 @@ export class AnarchitectsUiForm {
         }
       }
     });
+  }
+
+  fieldId(fieldName: string): string {
+    return fieldName;
+  }
+
+  fieldErrorMessage(fieldName: string): string | null {
+    const control = this.formGroup.get(fieldName);
+    if (!control || !control.touched || !control.invalid) {
+      return null;
+    }
+
+    if (control.hasError('required')) {
+      return 'This field is required.';
+    }
+
+    if (control.hasError('email')) {
+      return 'Enter a valid email address.';
+    }
+
+    if (control.hasError('minlength')) {
+      const requiredLength = control.getError('minlength')?.requiredLength;
+      return `Minimum length is ${requiredLength}.`;
+    }
+
+    if (control.hasError('maxlength')) {
+      const requiredLength = control.getError('maxlength')?.requiredLength;
+      return `Maximum length is ${requiredLength}.`;
+    }
+
+    return 'Invalid value.';
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const control = this.formGroup.get(fieldName);
+    return Boolean(control && control.touched && control.invalid);
   }
 
   onSubmit() {

--- a/libs/forms/angular/ui/src/index.ts
+++ b/libs/forms/angular/ui/src/index.ts
@@ -1,3 +1,5 @@
 export * from './form';
 
 export * from './submitted';
+export * from './submission-list';
+export * from './submission-detail';

--- a/libs/forms/angular/ui/src/submission-detail.css
+++ b/libs/forms/angular/ui/src/submission-detail.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.anx-forms-ui-submission-detail__content {
+  gap: var(--anx-sys-space-md);
+}
+
+.anx-forms-ui-submission-detail__header {
+  gap: var(--anx-sys-space-xs);
+}
+
+.anx-forms-ui-submission-detail__payload {
+  gap: var(--anx-sys-space-sm);
+  margin: 0;
+}
+
+.anx-forms-ui-submission-detail__row {
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: var(--anx-sys-space-sm);
+}
+
+.anx-forms-ui-submission-detail__row dt,
+.anx-forms-ui-submission-detail__row dd {
+  margin: 0;
+}
+
+.anx-forms-ui-submission-detail__row dd {
+  overflow-wrap: anywhere;
+}

--- a/libs/forms/angular/ui/src/submission-detail.html
+++ b/libs/forms/angular/ui/src/submission-detail.html
@@ -1,0 +1,35 @@
+<anarchitects-ui-layout-host
+  [kind]="'detail'"
+  [layout]="layout()"
+  [model]="layoutModel()"
+  [layoutOptions]="layoutOptions()"
+>
+  <ng-content select="ng-template[anxTemplate]"></ng-content>
+  <ng-content select="[anxSlot]"></ng-content>
+
+  <ng-template anxTemplate="content" let-model>
+    @if (model.data; as submission) {
+      <article class="anx-forms-ui-submission-detail__content anx-stack">
+        <header class="anx-forms-ui-submission-detail__header anx-stack">
+          <strong>{{ submission.formId }} (v{{ submission.formVersion }})</strong>
+          <span class="anx-text">
+            Submitted {{ formatDate(submission.createdAt) }}
+          </span>
+        </header>
+
+        <dl class="anx-forms-ui-submission-detail__payload anx-stack">
+          @for (entry of payloadEntries(submission); track entry.key) {
+            <div class="anx-forms-ui-submission-detail__row anx-grid">
+              <dt>{{ entry.key }}</dt>
+              <dd>{{ entry.value }}</dd>
+            </div>
+          }
+        </dl>
+      </article>
+    } @else {
+      <anarchitects-ui-alert [tone]="'neutral'" [appearance]="'ghost'">
+        Select a submission to view details.
+      </anarchitects-ui-alert>
+    }
+  </ng-template>
+</anarchitects-ui-layout-host>

--- a/libs/forms/angular/ui/src/submission-detail.spec.ts
+++ b/libs/forms/angular/ui/src/submission-detail.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { AnarchitectsFormsUiSubmissionDetail } from './submission-detail';
+
+describe('AnarchitectsFormsUiSubmissionDetail', () => {
+  let component: AnarchitectsFormsUiSubmissionDetail;
+  let fixture: ComponentFixture<AnarchitectsFormsUiSubmissionDetail>;
+  let ref: ComponentRef<AnarchitectsFormsUiSubmissionDetail>;
+
+  const mockSubmission: Submission = {
+    id: 'submission-1',
+    formId: 'contact',
+    formVersion: 1,
+    payload: { name: 'Jane Doe', email: 'jane@example.com' },
+    createdAt: new Date('2026-01-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnarchitectsFormsUiSubmissionDetail],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnarchitectsFormsUiSubmissionDetail);
+    component = fixture.componentInstance;
+    ref = fixture.componentRef;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render empty state when no submission is selected', () => {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    expect(nativeElement.textContent).toContain('Select a submission');
+  });
+
+  it('should render submission details', () => {
+    ref.setInput('submission', mockSubmission);
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    expect(nativeElement.textContent).toContain('contact');
+    expect(nativeElement.textContent).toContain('Jane Doe');
+    expect(nativeElement.textContent).toContain('jane@example.com');
+  });
+});

--- a/libs/forms/angular/ui/src/submission-detail.stories.ts
+++ b/libs/forms/angular/ui/src/submission-detail.stories.ts
@@ -1,0 +1,68 @@
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { AnarchitectsFormsUiSubmissionDetail } from './submission-detail';
+
+const sampleSubmission: Submission = {
+  id: 'submission-1',
+  formId: 'contact',
+  formVersion: 1,
+  payload: {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    message: 'Hello team',
+  },
+  createdAt: new Date('2026-01-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+};
+
+const meta: Meta<AnarchitectsFormsUiSubmissionDetail> = {
+  component: AnarchitectsFormsUiSubmissionDetail,
+  title: 'Forms UI/Submission Detail',
+  decorators: [
+    moduleMetadata({
+      imports: [AnxTemplateDirective],
+    }),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<AnarchitectsFormsUiSubmissionDetail>;
+
+export const Primary: Story = {
+  args: {
+    submission: sampleSubmission,
+  },
+};
+
+export const SidebarLayout: Story = {
+  args: {
+    submission: sampleSubmission,
+    layout: 'detail:sidebar',
+  },
+};
+
+export const TemplateOverride: Story = {
+  args: {
+    submission: sampleSubmission,
+    layout: 'detail:card',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <anarchitects-forms-ui-submission-detail
+        [submission]="submission"
+        [layout]="layout"
+      >
+        <ng-template anxTemplate="content" let-model>
+          <section class="anx-stack" style="gap: .25rem;">
+            <strong>Custom content template</strong>
+            <span>Form: {{ model.data?.formId }}</span>
+            <span>Version: {{ model.data?.formVersion }}</span>
+          </section>
+        </ng-template>
+      </anarchitects-forms-ui-submission-detail>
+    `,
+  }),
+};

--- a/libs/forms/angular/ui/src/submission-detail.ts
+++ b/libs/forms/angular/ui/src/submission-detail.ts
@@ -1,0 +1,75 @@
+import { Submission } from '@anarchitects/forms-ts/models';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { AnarchitectsUiAlert } from '@anarchitects/common-angular-ui-primitives/feedback';
+import { AnxSlotDirective } from '@anarchitects/common-angular-ui-composition/projection';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { provideAnxDefaultLayouts } from '@anarchitects/common-angular-ui-layouts/defaults';
+import { AnarchitectsUiLayoutHost } from '@anarchitects/common-angular-ui-layouts/host';
+
+type SubmissionPayloadEntry = {
+  key: string;
+  value: string;
+};
+
+@Component({
+  selector: 'anarchitects-forms-ui-submission-detail',
+  imports: [
+    AnarchitectsUiLayoutHost,
+    AnxTemplateDirective,
+    AnxSlotDirective,
+    AnarchitectsUiAlert,
+  ],
+  providers: [provideAnxDefaultLayouts()],
+  templateUrl: './submission-detail.html',
+  styleUrl: './submission-detail.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'anx-domain-component anx-forms-ui-submission-detail anx-stack',
+    'attr.data-anx-component': '"forms-ui-submission-detail"',
+  },
+})
+export class AnarchitectsFormsUiSubmissionDetail {
+  readonly submission = input<Submission | null>(null);
+  readonly title = input('Submission details');
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
+
+  readonly layoutModel = computed(() => ({
+    title: this.title(),
+    data: this.submission(),
+  }));
+
+  payloadEntries(submission: Submission): SubmissionPayloadEntry[] {
+    return Object.entries(submission.payload).map(([key, value]) => ({
+      key,
+      value: this.stringifyPayloadValue(value),
+    }));
+  }
+
+  formatDate(value: Date | string): string {
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+  }
+
+  private stringifyPayloadValue(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    return JSON.stringify(value);
+  }
+}

--- a/libs/forms/angular/ui/src/submission-list.css
+++ b/libs/forms/angular/ui/src/submission-list.css
@@ -1,0 +1,26 @@
+:host {
+  display: block;
+}
+
+.anx-forms-ui-submission-list__item {
+  gap: var(--anx-sys-space-sm);
+}
+
+.anx-forms-ui-submission-list__header {
+  justify-content: space-between;
+}
+
+.anx-forms-ui-submission-list__meta,
+.anx-forms-ui-submission-list__payload {
+  margin: 0;
+}
+
+.anx-forms-ui-submission-list__actions {
+  justify-content: flex-end;
+}
+
+.anx-forms-ui-submission-list__cell {
+  inline-size: 100%;
+  justify-content: space-between;
+  gap: var(--anx-sys-space-sm);
+}

--- a/libs/forms/angular/ui/src/submission-list.html
+++ b/libs/forms/angular/ui/src/submission-list.html
@@ -1,0 +1,53 @@
+<anarchitects-ui-layout-host
+  [kind]="'list'"
+  [layout]="layout()"
+  [model]="layoutModel()"
+  [layoutOptions]="layoutOptions()"
+>
+  <ng-content select="ng-template[anxTemplate]"></ng-content>
+  <ng-content select="[anxSlot]"></ng-content>
+
+  <ng-template anxTemplate="item" let-submission>
+    <article class="anx-forms-ui-submission-list__item anx-stack">
+      <header class="anx-forms-ui-submission-list__header anx-inline">
+        <strong>{{ submission.formId }}</strong>
+        <anarchitects-ui-badge [tone]="'neutral'" [appearance]="'outline'">
+          v{{ submission.formVersion }}
+        </anarchitects-ui-badge>
+      </header>
+
+      <p class="anx-forms-ui-submission-list__meta anx-text">
+        Submitted {{ formatDate(submission.createdAt) }}
+      </p>
+
+      <p class="anx-forms-ui-submission-list__payload anx-text">
+        {{ payloadFieldCount(submission) }} payload field(s)
+      </p>
+
+      <div class="anx-forms-ui-submission-list__actions anx-inline">
+        <anarchitects-ui-button
+          [size]="'sm'"
+          [appearance]="'outline'"
+          (pressed)="onSelect(submission)"
+        >
+          View details
+        </anarchitects-ui-button>
+      </div>
+    </article>
+  </ng-template>
+
+  <ng-template anxTemplate="cell" let-submission>
+    <div class="anx-forms-ui-submission-list__cell anx-inline">
+      <span>
+        {{ submission.formId }} (v{{ submission.formVersion }})
+      </span>
+      <anarchitects-ui-button
+        [size]="'sm'"
+        [appearance]="'ghost'"
+        (pressed)="onSelect(submission)"
+      >
+        Open
+      </anarchitects-ui-button>
+    </div>
+  </ng-template>
+</anarchitects-ui-layout-host>

--- a/libs/forms/angular/ui/src/submission-list.spec.ts
+++ b/libs/forms/angular/ui/src/submission-list.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { AnarchitectsFormsUiSubmissionList } from './submission-list';
+
+describe('AnarchitectsFormsUiSubmissionList', () => {
+  let component: AnarchitectsFormsUiSubmissionList;
+  let fixture: ComponentFixture<AnarchitectsFormsUiSubmissionList>;
+  let ref: ComponentRef<AnarchitectsFormsUiSubmissionList>;
+
+  const mockSubmissions: Submission[] = [
+    {
+      id: 'submission-1',
+      formId: 'contact',
+      formVersion: 1,
+      payload: { name: 'Jane Doe', email: 'jane@example.com' },
+      createdAt: new Date('2026-01-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnarchitectsFormsUiSubmissionList],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnarchitectsFormsUiSubmissionList);
+    component = fixture.componentInstance;
+    ref = fixture.componentRef;
+    ref.setInput('submissions', mockSubmissions);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render submission content in default item template', () => {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    expect(nativeElement.textContent).toContain('contact');
+    expect(nativeElement.textContent).toContain('View details');
+  });
+
+  it('should emit selected submission', () => {
+    const emitSpy = jest.spyOn(component.selected, 'emit');
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const button = nativeElement.querySelector('button');
+
+    expect(button).toBeTruthy();
+    button?.click();
+
+    expect(emitSpy).toHaveBeenCalledWith(mockSubmissions[0]);
+  });
+});

--- a/libs/forms/angular/ui/src/submission-list.stories.ts
+++ b/libs/forms/angular/ui/src/submission-list.stories.ts
@@ -1,0 +1,74 @@
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { Submission } from '@anarchitects/forms-ts/models';
+import { AnarchitectsFormsUiSubmissionList } from './submission-list';
+
+const sampleSubmissions: Submission[] = [
+  {
+    id: 'submission-1',
+    formId: 'contact',
+    formVersion: 1,
+    payload: { name: 'Jane Doe', email: 'jane@example.com' },
+    createdAt: new Date('2026-01-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+  },
+  {
+    id: 'submission-2',
+    formId: 'contact',
+    formVersion: 2,
+    payload: { name: 'John Smith', message: 'Hello' },
+    createdAt: new Date('2026-01-02T11:30:00.000Z'),
+    updatedAt: new Date('2026-01-02T11:30:00.000Z'),
+  },
+];
+
+const meta: Meta<AnarchitectsFormsUiSubmissionList> = {
+  component: AnarchitectsFormsUiSubmissionList,
+  title: 'Forms UI/Submission List',
+  decorators: [
+    moduleMetadata({
+      imports: [AnxTemplateDirective],
+    }),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<AnarchitectsFormsUiSubmissionList>;
+
+export const Primary: Story = {
+  args: {
+    submissions: sampleSubmissions,
+  },
+};
+
+export const GridLayout: Story = {
+  args: {
+    submissions: sampleSubmissions,
+    layout: 'list:grid',
+    layoutOptions: { columns: 2 },
+  },
+};
+
+export const TemplateOverride: Story = {
+  args: {
+    submissions: sampleSubmissions,
+    layout: 'list:card',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <anarchitects-forms-ui-submission-list
+        [submissions]="submissions"
+        [layout]="layout"
+      >
+        <ng-template anxTemplate="item" let-submission>
+          <section class="anx-stack" style="gap: .25rem;">
+            <strong>Custom: {{ submission.formId }}</strong>
+            <span>Payload fields: {{ submission.payload ? 'available' : 'none' }}</span>
+          </section>
+        </ng-template>
+      </anarchitects-forms-ui-submission-list>
+    `,
+  }),
+};

--- a/libs/forms/angular/ui/src/submission-list.ts
+++ b/libs/forms/angular/ui/src/submission-list.ts
@@ -1,0 +1,60 @@
+import { Submission } from '@anarchitects/forms-ts/models';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { AnarchitectsUiButton } from '@anarchitects/common-angular-ui-primitives/actions';
+import { AnarchitectsUiBadge } from '@anarchitects/common-angular-ui-primitives/feedback';
+import { AnxSlotDirective } from '@anarchitects/common-angular-ui-composition/projection';
+import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
+import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { provideAnxDefaultLayouts } from '@anarchitects/common-angular-ui-layouts/defaults';
+import { AnarchitectsUiLayoutHost } from '@anarchitects/common-angular-ui-layouts/host';
+
+@Component({
+  selector: 'anarchitects-forms-ui-submission-list',
+  imports: [
+    AnarchitectsUiLayoutHost,
+    AnxTemplateDirective,
+    AnxSlotDirective,
+    AnarchitectsUiButton,
+    AnarchitectsUiBadge,
+  ],
+  providers: [provideAnxDefaultLayouts()],
+  templateUrl: './submission-list.html',
+  styleUrl: './submission-list.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'anx-domain-component anx-forms-ui-submission-list anx-stack',
+    'attr.data-anx-component': '"forms-ui-submission-list"',
+  },
+})
+export class AnarchitectsFormsUiSubmissionList {
+  readonly submissions = input<readonly Submission[]>([]);
+  readonly title = input('Submissions');
+  readonly layout = input<AnxLayoutId | null>(null);
+  readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
+
+  readonly selected = output<Submission>();
+
+  readonly layoutModel = computed(() => ({
+    title: this.title(),
+    items: this.submissions(),
+  }));
+
+  onSelect(submission: Submission): void {
+    this.selected.emit(submission);
+  }
+
+  payloadFieldCount(submission: Submission): number {
+    return Object.keys(submission.payload).length;
+  }
+
+  formatDate(value: Date | string): string {
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+  }
+}


### PR DESCRIPTION
- refactor `anarchitects-forms-ui-form` to use primitives, `anarchitects-ui-layout-host`, and canonical `anxTemplate`/`anxSlot` hooks
- add domain UI components: `anarchitects-forms-ui-submission-list` and `anarchitects-forms-ui-submission-detail`
- add feature orchestration components for submission list/detail with provider-scoped state
- update feature/UI exports, stories, and README docs for layout + template extensibility
- add required peer dependencies on common Angular design/composition/layout/primitives packages