### PR TITLE
chore(release-tools): add release tag ancestry preflight to nx release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,10 @@ nx run forms-angular-example:contract-test
 - Before release PRs, normalize publishable package dependency ranges:
   - `nx run release-tools:normalize-internal-deps`
   - `nx run release-tools:normalize-external-peer-ranges`
+  - `nx run release-tools:check-release-tag-ancestry`
   - external peer normalization derives ranges from root `package.json`; exact root versions become major-wide caret peers (for example `21.1.6` -> `^21.0.0`)
+- The release tag ancestry check fails when a `{projectName}@{version}` tag exists but points to a commit outside current branch history.
+- For local dry-run validation, target only changed projects when possible (for example `nx release version --projects=auth-angular -d`).
 - Keep domain tags aligned with folder structure; CI validates:
   - `libs/forms/**` -> `domain:forms`
   - `libs/auth/**` -> `domain:auth`

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Run releases via the **Release (Manual)** GitHub workflow:
 - Use **Publish Packages (Recovery)** only to retry publish if a release run fails after versioning/tagging.
 
 Avoid routine local `yarn nx release`; use the workflow for auditable, controlled domain releases.
+If local dry-runs are needed, run `nx run release-tools:check-release-tag-ancestry` first to ensure existing `{projectName}@{version}` tags are reachable from the current branch.
 
 ## Layering Rules
 

--- a/nx.json
+++ b/nx.json
@@ -192,7 +192,7 @@
       }
     },
     "version": {
-      "preVersionCommand": "yarn nx run-many -t build",
+      "preVersionCommand": "yarn nx run release-tools:check-release-tag-ancestry && yarn nx run-many -t build",
       "conventionalCommits": true,
       "updateDependents": "never"
     },

--- a/tools/release/check-release-tag-ancestry.mjs
+++ b/tools/release/check-release-tag-ancestry.mjs
@@ -1,0 +1,121 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const workspaceRoot = process.cwd();
+const libsRoot = join(workspaceRoot, 'libs');
+
+function walkDirectories(rootDir, fileName) {
+  const stack = [rootDir];
+  const files = [];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (entry.isFile() && entry.name === fileName) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function runGit(args) {
+  return spawnSync('git', args, { cwd: workspaceRoot, encoding: 'utf8' });
+}
+
+function resolveTagCommit(tagName) {
+  const result = runGit(['rev-parse', '--verify', '--quiet', `refs/tags/${tagName}^{commit}`]);
+  if (result.status !== 0) {
+    return null;
+  }
+
+  return result.stdout.trim();
+}
+
+function isAncestor(commitHash) {
+  const result = runGit(['merge-base', '--is-ancestor', commitHash, 'HEAD']);
+  return result.status === 0;
+}
+
+function isPublishableProject(projectDir, packageJson) {
+  return Boolean(
+    packageJson &&
+      typeof packageJson === 'object' &&
+      packageJson.publishConfig &&
+      typeof packageJson.version === 'string',
+  );
+}
+
+const projectJsonFiles = walkDirectories(libsRoot, 'project.json');
+const mismatches = [];
+let checkedTags = 0;
+
+for (const projectJsonPath of projectJsonFiles) {
+  const projectDir = join(projectJsonPath, '..');
+  const packageJsonPath = join(projectDir, 'package.json');
+
+  if (!existsSync(packageJsonPath)) {
+    continue;
+  }
+
+  const projectJson = JSON.parse(readFileSync(projectJsonPath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const projectName = projectJson.name;
+
+  if (typeof projectName !== 'string' || !isPublishableProject(projectDir, packageJson)) {
+    continue;
+  }
+
+  const version = packageJson.version;
+  const tagName = `${projectName}@${version}`;
+  const tagCommit = resolveTagCommit(tagName);
+
+  if (!tagCommit) {
+    continue;
+  }
+
+  checkedTags += 1;
+
+  if (!isAncestor(tagCommit)) {
+    mismatches.push({
+      projectName,
+      version,
+      tagName,
+      tagCommit,
+      projectJsonPath: relative(workspaceRoot, projectJsonPath),
+    });
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error('Release tag ancestry preflight failed.');
+  console.error(
+    'The following project tag(s) exist but point to commits outside the current branch history:',
+  );
+
+  for (const mismatch of mismatches) {
+    console.error(
+      `- ${mismatch.tagName} (${mismatch.tagCommit}) [${mismatch.projectJsonPath}]`,
+    );
+  }
+
+  console.error(
+    'Fix by moving each tag to the intended reachable release baseline before running nx release.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Release tag ancestry preflight passed for ${checkedTags} tag(s) that match current project versions.`,
+);

--- a/tools/release/project.json
+++ b/tools/release/project.json
@@ -23,6 +23,12 @@
       "options": {
         "command": "node tools/release/normalize-external-peer-ranges.mjs"
       }
+    },
+    "check-release-tag-ancestry": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/release/check-release-tag-ancestry.mjs"
+      }
     }
   }
 }


### PR DESCRIPTION
- add release-tools target `check-release-tag-ancestry`
- add `tools/release/check-release-tag-ancestry.mjs` to fail when `{projectName}@{version}` tags are not ancestors of HEAD
- wire preflight into `release.version.preVersionCommand` in nx.json
- document the new preflight and local dry-run guidance in CONTRIBUTING.md and README.md