### PR TITLE
docs: split TS contract ownership guide and refocus Angular/Nest cookbooks

### DIFF
--- a/docs/guides/angular.md
+++ b/docs/guides/angular.md
@@ -2,182 +2,90 @@
 
 ## Intent
 
-This guide explains how to build Angular applications with Anarchitecture Bricks using a layered architecture plus a contract-first design and UI system. It focuses on practical integration patterns, copy/paste setup steps, and safe extension points for teams consuming `@anarchitects/*` packages.
+This is the Angular implementation cookbook for Anarchitecture Bricks. It focuses on practical Angular setup and consumption patterns, while shared design/runtime guidance and TS contract ownership stay canonical in:
 
-For shared cross-stack rules, also use the [Design/UI Systems Guide](/guides/design-ui-systems.html).
+- [Design/UI Systems Guide](/guides/design-ui-systems.html)
+- [TS Contracts Guide](/guides/ts-contracts.html)
 
 ## Architecture
 
-- Angular domain libraries follow: `ui <- feature -> state -> data-access`.
-- Shared contracts come from TS packages (`@anarchitects/*-ts`) and generated API contracts.
-- `config` and `util` are cross-layer helpers; avoid bypassing layer boundaries.
-- State registration is explicit via provider helpers; no implicit global singleton store registration.
+- Angular libraries follow `ui <- feature -> state -> data-access`.
+- `config` and `util` are shared helpers available across layers.
+- TS contracts are consumed from domain TS packages; Angular layers do not redefine ownership contracts.
+- State scope stays explicit through provider helpers (no implicit global singleton state).
 
-## Design System Foundations
+## Easy Mode with Root Exports
 
-Treat the design/UI stack as layered infrastructure:
-
-1. `@anarchitects/common-angular-design`
-2. `@anarchitects/common-angular-ui-composition`
-3. `@anarchitects/common-angular-ui-primitives`
-4. `@anarchitects/common-angular-ui-layouts`
-5. domain UI packages (`@anarchitects/forms-angular/ui`, `@anarchitects/auth-angular/ui`, etc.)
-
-Design package responsibilities:
-
-- `common-angular-design`: token contracts, semantic hooks, base scoped styles, typed design config providers.
-- `common-angular-ui-composition`: canonical slot/template contracts (`anxSlot`, `anxTemplate`) and projection conventions.
-- `common-angular-ui-primitives`: non-branded reusable UI building blocks aligned to token contracts.
-- `common-angular-ui-layouts`: runtime-selectable layout host/registry/defaults with deterministic fallback.
-
-## Quick Start with Design/UI Stack
-
-Bootstrap design context first, then wire domain packages:
+Use root package exports for fastest onboarding and lowest host-app wiring cost:
 
 ```ts
 import { provideHttpClient, withFetch } from '@angular/common/http';
-import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
-import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
-import { provideFormsDefaults } from '@anarchitects/forms-angular/config';
-import { provideAuthConfig } from '@anarchitects/auth-angular/config';
-import { provideAuthDataAccess } from '@anarchitects/auth-angular/data-access';
-import { provideAuthState } from '@anarchitects/auth-angular/state';
-
-applyAnxBaseStyles();
+import { provideFormsFeature } from '@anarchitects/forms-angular';
+import { provideAuthFeature } from '@anarchitects/auth-angular';
 
 export const appConfig = {
-  providers: [
-    ...provideDesignSystemConfig({
-      theme: 'default',
-      density: 'comfortable',
-      surface: 'plain',
-      layout: 'list',
-      columns: 1,
-    }),
-    provideHttpClient(withFetch()),
-    provideFormsDefaults(),
-    provideAuthConfig({ apiBaseUrl: 'https://api.example.com' }),
-    provideAuthDataAccess(),
-    provideAuthState(),
-  ],
+  providers: [provideHttpClient(withFetch()), ...provideFormsFeature(), ...provideAuthFeature()],
 };
 ```
 
-This ordering keeps design tokens and semantic hooks available before feature/UI components render.
+Easy mode is the default for product teams that want stable integration points with minimal setup decisions.
 
-## Theme and Token Customization
+## Advanced Mode with Secondary Entry Points
 
-Keep shared libraries unbranded. Brand at app edges with tokens and scoped hooks:
+Use layer-specific entry points when you need targeted overrides:
 
-- Override system tokens (`--anx-sys-*`, `--anx-layout-*`) in application styles.
-- Use `data-anx-theme`, `data-anx-density`, `data-anx-surface`, `data-anx-layout` for controlled context switching.
-- Keep component wrappers in app code if product-specific styling or behavior diverges.
+- `@anarchitects/forms-angular/config`
+- `@anarchitects/forms-angular/data-access`
+- `@anarchitects/forms-angular/state`
+- `@anarchitects/forms-angular/feature`
+- `@anarchitects/forms-angular/ui`
+- `@anarchitects/forms-angular/util`
+- `@anarchitects/auth-angular/config`
+- `@anarchitects/auth-angular/data-access`
+- `@anarchitects/auth-angular/state`
+- `@anarchitects/auth-angular/feature`
+- `@anarchitects/auth-angular/ui`
+- `@anarchitects/auth-angular/util`
 
-Example:
+Use advanced mode for custom transport adapters, scoped state lifecycles, or domain-specific feature composition without breaking the easy root-consumption path.
 
-```css
-.anx-root[data-anx-theme='enterprise'] {
-  --anx-sys-color-primary: #0f766e;
-  --anx-sys-color-surface: #f8fafc;
-  --anx-layout-content-max-width: 72rem;
-}
-```
+## TS Contract Integration
 
-## UI Composition and Primitives
+Contract ownership remains in TS packages:
 
-Build composition APIs around canonical slots and templates so features stay wrapper-friendly and theme-safe:
+- Forms contracts: `@anarchitects/forms-ts`
+- Auth contracts: `@anarchitects/auth-ts`
 
-- Use slot contracts (`anxSlot="header|content|footer|actions|..."`) for projected content.
-- Use template contracts (`ng-template[anxTemplate]`) for customizable repeated/empty/content states.
-- Prefer canonical slot names in new code; keep alias compatibility only as migration support.
-- Keep primitives behavior-agnostic; feature/state layers own orchestration and domain decisions.
-
-Example:
-
-```html
-<anarchitects-ui-card>
-  <div anxSlot="header">Profile</div>
-  <p anxSlot="content">User details</p>
-  <div anxSlot="footer">
-    <button anxSlot="actions">Save</button>
-  </div>
-</anarchitects-ui-card>
-
-<ng-template anxTemplate="empty">No items</ng-template>
-```
-
-## Composition Cookbook
-
-Use these repeatable patterns in feature and domain UI libraries:
-
-- Pattern: stable projection API
-  Use `anxSlot` names as public contract and avoid renaming existing slots once published.
-- Pattern: app-level template specialization
-  Accept templates via `anxTemplate` and let host apps provide alternate rendering for item/empty/action regions.
-- Pattern: wrapper extension
-  Wrap primitives in app-level components for branding or behavior rather than patching shared primitives.
-- Pattern: compatibility migration
-  Keep alias support (`anxStart`, `anxEnd`, etc.) only while migrating to canonical slots.
-
-## Layout Runtime
-
-Use `@anarchitects/common-angular-ui-layouts` for runtime layout selection with deterministic precedence:
-
-1. explicit host input (`[layout]`)
-2. provider defaults (`ANX_LAYOUT_DEFAULTS[kind]`)
-3. built-in fallback by kind
-
-Use layout runtime when you need app-level layout variation without forking domain UI components. Keep custom renderers as app-level extensions registered through provider APIs instead of domain-library code changes.
+Angular consumers (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`) map TS contracts in `data-access` and `state`, then expose stable UI/feature APIs. For contract ownership, change workflow, and compatibility policy, follow [TS Contracts Guide](/guides/ts-contracts.html).
 
 ## Layout Cookbook
 
-- Pattern: explicit route-level layout
-  Set `[layout]` from route metadata when a screen requires deterministic rendering.
-- Pattern: domain defaults
-  Use `provideAnxLayoutDefaults(...)` for consistent kind defaults across a product area.
-- Pattern: product override
-  Register custom renderers with `provideAnxLayouts([...])` while preserving fallback behavior.
-- Pattern: safe fallback
-  Always keep built-in layout kind fallbacks so missing custom registrations do not break rendering.
-
-## App Composition
-
-Start with root providers in app bootstrap:
-
-1. Provide design context (`provideDesignSystemConfig`) and apply base styles once.
-2. Provide domain config (`provide*Config`), then data-access (`provide*DataAccess`).
-3. Provide state (`provide*State`) at app, route, or feature scope as needed.
-4. Use feature entry points for orchestration and UI entry points for presentational rendering.
-
-Domain package strategy:
-
-- `@anarchitects/forms-angular`: dynamic form retrieval/rendering/submission with config/data-access/state/feature/ui slices.
-- `@anarchitects/auth-angular`: auth orchestration with config/data-access/state/feature/util/ui slices.
-- Keep design/UI infrastructure package usage consistent across both domains to avoid divergent UX contracts.
+- Configure layout runtime through `@anarchitects/common-angular-ui-layouts`.
+- Use explicit layout input when route behavior must be deterministic.
+- Set defaults with `provideAnxLayoutDefaults(...)`.
+- Register custom layout renderers with `provideAnxLayouts([...])`.
+- Keep design/runtime layout contract definitions centralized in [Design/UI Systems Guide](/guides/design-ui-systems.html).
 
 ## State/Data Access
 
-- Keep HTTP integration inside `data-access`; never call endpoints directly from UI/feature components.
-- Let `state` orchestrate loading/error/retry/cache and expose derived UI signals.
-- Keep `ui` components presentational and token-driven; receive data via inputs and emit interaction events.
-- Keep route/API contracts synced with backend by regenerating OpenAPI and updating generated clients after schema changes.
-- Keep design-system decisions (theme, density, surface, layout defaults) outside domain state.
+- Keep HTTP and endpoint adapters in `data-access`.
+- Keep stateful orchestration and derived UI signals in `state`.
+- Keep `feature` as composition/orchestration and `ui` as presentational/token-driven.
+- Sync backend schema changes by regenerating OpenAPI and updating Angular adapters before merge.
 
 ## Testing and Docs Workflow
 
-- Unit-test feature/state logic independently from primitive visuals.
-- Snapshot or interaction-test wrapper components for slot/template behavior.
-- Validate docs quality with `yarn nx run docs-hub:validate-content`.
-- Rebuild docs output with `yarn nx run docs-hub:build`.
-- Verify rendered output and required links with `yarn nx run docs-hub:verify`.
-- When backend contracts change, run OpenAPI generation and validate affected UI flows before merge.
+- Unit-test `state` and `feature` layers independently of primitive visuals.
+- Run docs quality checks:
+  `yarn nx run docs-hub:validate-content`,
+  `yarn nx run docs-hub:build`,
+  `yarn nx run docs-hub:verify`.
+- Run contract-aligned flows for forms/auth after TS or API changes.
 
 ## Common Pitfalls
 
-- Treating design packages as optional styling instead of foundational contracts.
-- Hardcoding app branding inside shared primitives instead of consumer overlays/tokens.
-- Mixing orchestration logic into UI components or primitives.
-- Registering stores globally by default without intended scope.
-- Bypassing generated API clients with manual endpoint strings.
-- Importing internal source paths instead of published secondary entry points.
-- Skipping OpenAPI/client resync after DTO/schema updates.
+- Bypassing root exports for routine use cases and over-fragmenting app setup.
+- Coupling UI components directly to transport concerns instead of `data-access`.
+- Using internal source imports instead of published entry points.
+- Treating TS contracts as Angular-owned instead of TS-owned.
+- Skipping OpenAPI/client sync after schema changes.

--- a/docs/guides/design-ui-systems.md
+++ b/docs/guides/design-ui-systems.md
@@ -4,6 +4,8 @@
 
 This guide defines the cross-stack design and UI system model for Anarchitecture Bricks. It explains how to consume `@anarchitects/*` packages so design contracts, composition APIs, and runtime layouts stay consistent across domains and applications.
 
+Contract ownership for DTOs and domain models is defined in the canonical [TS Contracts Guide](/guides/ts-contracts.html).
+
 ## System Layers
 
 The UI system is layered and should be adopted in order:

--- a/docs/guides/nest.md
+++ b/docs/guides/nest.md
@@ -2,119 +2,95 @@
 
 ## Intent
 
-This guide describes how to compose NestJS applications from Anarchitecture Bricks while preserving strict backend layering and producing stable contracts for Angular design/UI consumers.
+This is the Nest implementation cookbook for Anarchitecture Bricks. It focuses on backend module composition and entry-point usage, while shared cross-stack contracts stay canonical in:
 
-For shared cross-stack design and UI contracts, also use the [Design/UI Systems Guide](/guides/design-ui-systems.html).
+- [TS Contracts Guide](/guides/ts-contracts.html)
+- [Design/UI Systems Guide](/guides/design-ui-systems.html)
 
 ## Architecture
 
 - Nest libraries follow: `presentation -> application <- infrastructure`.
-- Shared contracts (DTOs/models/schemas) come from `@anarchitects/*-ts`.
-- Domain modules expose both facade imports and secondary entry points.
-- Controllers must keep `@RouteSchema` fields pure and imported from shared DTO/schema packages.
-- OpenAPI metadata remains centralized in specs tooling, not inside controllers.
+- Shared contracts (DTOs/models/schemas) are consumed from TS packages (`@anarchitects/forms-ts`, `@anarchitects/auth-ts`).
+- Domain libraries expose both facade composition modules and layer-specific secondary entry points.
+- Controllers keep `@RouteSchema` pure and imported from TS contract libraries.
+- OpenAPI metadata is assigned centrally in specs tooling.
 
-## Module Composition
+## Easy Mode with Composition Modules
 
-Use one of two integration styles:
+Use facade composition modules for the default host-app path:
 
-1. **Facade mode**: import root module and call `forRoot(...)` for fast setup.
-2. **Advanced mode**: compose `application`, `presentation`, and infrastructure modules individually for targeted overrides.
+```ts
+import { Module } from '@nestjs/common';
+import { FormsModule } from '@anarchitects/forms-nest';
+import { AuthModule } from '@anarchitects/auth-nest';
 
-Prefer facade mode for host applications by default. Use advanced composition only when replacing persistence/mailer adapters, layering custom modules, or integrating alternative infrastructure.
+@Module({
+  imports: [
+    FormsModule.forRoot({}),
+    FormsModule.forRootFromConfig(),
+    AuthModule.forRoot({}),
+    AuthModule.forRootFromConfig(),
+  ],
+})
+export class AppModule {}
+```
 
-## Configuration
+Easy mode is preferred when teams want predictable integration and minimal Nest wiring.
 
-- Use typed `registerAs(...)` config exports from each domain/config entry point.
-- Prefer `forRootFromConfig(...)` when runtime behavior is environment-driven.
-- Maintain consistent precedence: explicit overrides > config values > defaults.
-- Keep secrets and runtime values in host app config, not in domain logic.
-- Configure shared transports once at app root (mailer, etc.), then keep domain modules adapter-thin.
+## Advanced Mode with Layer Entry Points
 
-## UI Contract Support
+Use layered entry points when you need explicit control over domain composition:
 
-Nest modules should explicitly support frontend design/UI systems by returning stable, implementation-aligned contracts:
+- `@anarchitects/forms-nest/application`
+- `@anarchitects/forms-nest/presentation`
+- `@anarchitects/forms-nest/infrastructure-*`
+- `@anarchitects/forms-nest/config`
+- `@anarchitects/auth-nest/application`
+- `@anarchitects/auth-nest/presentation`
+- `@anarchitects/auth-nest/infrastructure-*`
+- `@anarchitects/auth-nest/config`
 
-- Preserve schema compatibility for frontend rendering surfaces (forms, auth flows, validation payloads).
-- Keep DTO/schema evolution additive when possible to avoid breaking Angular UI composition/layout expectations.
-- Keep endpoint semantics deterministic so state and layout selection logic can stay in frontend layers.
-- Avoid leaking backend persistence details into API contracts consumed by `@anarchitects/*-angular`.
+Advanced mode is for replacing adapters, customizing policy wiring, or composing only selected layers while preserving facade compatibility.
 
-Practical cross-stack guidance:
+## TS Contract Integration
 
-- `@anarchitects/forms-nest` should continue exposing predictable form definition/submission contracts that Angular feature/UI layers can render dynamically.
-- `@anarchitects/auth-nest` should keep auth lifecycle contracts stable so Angular state/feature layers can orchestrate policies and session flows consistently.
-- Treat OpenAPI output as the source for client sync; frontend layers depend on it for contract-safe rendering.
+Contract ownership is TS-first:
 
-## Contract Design for UI Consumers
+- Forms contracts in `@anarchitects/forms-ts`
+- Auth contracts in `@anarchitects/auth-ts`
 
-Design backend contracts as UI-facing building blocks:
+Nest libraries (`@anarchitects/forms-nest`, `@anarchitects/auth-nest`) map these contracts in presentation/application layers and keep schemas synchronized for OpenAPI generation. Ownership and compatibility policy are defined in [TS Contracts Guide](/guides/ts-contracts.html).
 
-- Keep field names and structures stable across versions when consumed by `@anarchitects/forms-angular` and `@anarchitects/auth-angular`.
-- Return explicit enums/flags that allow frontend layout or state decisions without brittle string parsing.
-- Keep validation and error payload shapes predictable so UI primitives can render consistent feedback.
-- Avoid backend-specific persistence implementation details in response DTOs.
+## Library Entry Point Cookbook
+
+- Fast start:
+  use root module imports (`@anarchitects/forms-nest`, `@anarchitects/auth-nest`) with `forRoot` or `forRootFromConfig`.
+- Config-driven environments:
+  prefer `forRootFromConfig` with typed `registerAs` config.
+- Adapter override:
+  keep facade contract stable, then replace only targeted `infrastructure-*` pieces through secondary entry points.
+- Partial composition:
+  combine `application` and selected `presentation`/`infrastructure-*` modules when host apps need strict control.
 
 ## Schema Evolution and Compatibility
 
-Follow a compatibility-first change strategy:
-
-- Add new optional fields before introducing required replacements.
-- Deprecate fields in docs first, then remove only after consumer migration windows.
-- Keep existing endpoints behaviorally stable while introducing new capabilities.
-- Coordinate contract updates through shared TS DTO packages and OpenAPI regeneration in one change-set.
-
-## Forms and Auth Contract Mapping
-
-Cross-stack mapping guidance:
-
-- Forms domain:
-  keep form definition and submission contracts stable so Angular runtime layouts (`form:*`, `list:*`, `detail:*`) keep rendering without custom edge logic.
-- Auth domain:
-  keep lifecycle routes (register/login/logout/refresh/activate/reset) consistent so Angular state and policy guards remain deterministic.
-- Both domains:
-  keep contract changes synchronized with `@anarchitects/*-ts` and frontend client updates.
-
-## Infrastructure Boundaries
-
-- Keep infrastructure modules adapter-focused and thin.
-- Avoid cross-domain TypeORM relations in entities; use scalar foreign keys and integration schemas for cross-domain FK constraints.
-- Keep domain internals isolated behind exported tokens/contracts.
-- When cross-domain reads are needed, use application composition or dedicated query integrations, not cross-domain entity relations.
-
-## Design/UI-System Aware API Evolution
-
-When changing backend behavior that influences UI composition:
-
-- Update shared TS contracts first (`@anarchitects/*-ts`), then implementation.
-- Regenerate OpenAPI and validate downstream client/generator outputs.
-- Ensure route schema changes preserve clear migration paths for Angular feature/UI consumers.
-- Keep response payloads explicit enough for frontend layout/composition decisions, but free of presentation styling concerns.
-
-## Cookbook for UI-Impacting Backend Changes
-
-- Change: add UI-facing field to existing response
-  Update shared DTO, update controller schema import, regenerate OpenAPI, update frontend adapter/state mapping, run contract tests.
-- Change: new flow endpoint (for example auth recovery extension)
-  Add route schema in TS contracts first, implement controller/service, map OpenAPI metadata centrally, then integrate frontend feature/state.
-- Change: forms payload evolution
-  Introduce additive fields and keep existing schema keys valid until frontend migration is complete.
-- Change: mailer or persistence adapter swap
-  Keep facade contracts unchanged; limit changes to infrastructure wiring.
+- Introduce additive fields before removals.
+- Keep backward-compatible schema keys during migration windows.
+- Coordinate TS + Nest + Angular updates in one change when compatibility risk exists.
+- Preserve stable contracts required by frontend composition and runtime layout behavior.
 
 ## Contract Verification Workflow
 
-- Validate route schemas remain imported from shared TS DTO libraries (no inline drift).
-- Run OpenAPI generation and inspect diff for breaking changes.
-- Run frontend contract consumers against updated clients for forms/auth critical paths.
-- Run docs checks to keep guidance aligned:
+- Validate that controller schemas import TS contracts (no inline drift).
+- Run OpenAPI generation and inspect diffs for compatibility impact.
+- Verify Angular consumers (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`) against updated contracts.
+- Run docs quality checks:
   `yarn nx run docs-hub:validate-content`, `yarn nx run docs-hub:build`, `yarn nx run docs-hub:verify`.
 
 ## Common Pitfalls
 
-- Defining OpenAPI metadata directly in controllers instead of centralized metadata mapping.
-- Bypassing shared DTO schemas with inline route schema definitions.
-- Coupling domain modules to environment access directly.
-- Mixing cross-domain persistence relations into runtime entity models.
-- Re-implementing transport/provider wiring per domain instead of reusing shared infrastructure bricks.
-- Introducing backend contract changes without verifying impact on Angular design/UI rendering flows.
+- Treating Nest libraries as contract owners instead of TS consumers.
+- Skipping facade modules and jumping to layer entry points for simple use cases.
+- Defining inline route schemas instead of importing TS DTO schemas.
+- Mixing persistence internals across domain boundaries.
+- Introducing schema changes without verifying cross-stack consumer impact.

--- a/docs/guides/ts-contracts.md
+++ b/docs/guides/ts-contracts.md
@@ -1,0 +1,77 @@
+# TS Contracts Guide
+
+## Intent
+
+This guide is the canonical source for contract ownership in Anarchitecture Bricks. It defines where DTOs, schema contracts, and domain models live, and how Angular and Nest libraries consume them.
+
+For shared design/runtime UI contracts, see [Design/UI Systems Guide](/guides/design-ui-systems.html).
+
+## Contract Ownership Model
+
+- Contract source of truth is the domain TS packages: `@anarchitects/forms-ts` and `@anarchitects/auth-ts`.
+- Angular and Nest packages consume contracts; they do not own contract definitions.
+- OpenAPI generation must be derived from controller route schemas that import from TS contract packages.
+- Contract changes should be introduced in TS first, then propagated to Nest/Angular consumers in the same change-set.
+
+## Domain Contract Matrix
+
+| Domain | Canonical TS Contract Package | Angular Consumer | Nest Consumer |
+| --- | --- | --- | --- |
+| Forms | `@anarchitects/forms-ts` | `@anarchitects/forms-angular` | `@anarchitects/forms-nest` |
+| Auth | `@anarchitects/auth-ts` | `@anarchitects/auth-angular` | `@anarchitects/auth-nest` |
+
+## Forms TS Contracts
+
+Use `@anarchitects/forms-ts` for:
+
+- form definition DTOs and schema fields used by dynamic rendering
+- form submission payloads and validation response contracts
+- domain-level model shapes that both frontend and backend depend on
+
+Do not redefine Forms contracts inside `@anarchitects/forms-angular` or `@anarchitects/forms-nest`.
+
+## Auth TS Contracts
+
+Use `@anarchitects/auth-ts` for:
+
+- auth lifecycle DTOs (register, login, refresh, activate, reset flows)
+- session/token response shapes and policy-relevant flags
+- shared auth model types that must stay stable across frontend/backend
+
+Do not redefine Auth contracts inside `@anarchitects/auth-angular` or `@anarchitects/auth-nest`.
+
+## Consumer Mapping (Angular and Nest)
+
+- Angular (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`):
+  consume TS contracts in data-access/state adapters and keep UI/feature layers contract-safe.
+- Nest (`@anarchitects/forms-nest`, `@anarchitects/auth-nest`):
+  import TS contracts in presentation/application layers and keep controller route schemas aligned.
+- Design/UI behavior depends on stable contracts:
+  keep DTO evolution coordinated with frontend runtime layout and composition expectations.
+
+## Contract Change Workflow
+
+1. Update contract types/schemas in `@anarchitects/forms-ts` or `@anarchitects/auth-ts`.
+2. Update Nest route schema imports and application mappings.
+3. Regenerate OpenAPI artifacts and inspect for breaking changes.
+4. Update Angular data-access/state adapters and feature orchestration.
+5. Run contract and docs validation before merge.
+
+## Compatibility Rules
+
+- Prefer additive changes first (new optional fields).
+- Deprecate before remove, and document migration windows.
+- Keep endpoint behavior stable while introducing new capabilities.
+- Avoid renaming/removing contract keys without synchronized consumer updates.
+- When a breaking change is unavoidable, coordinate TS, Nest, Angular, and docs in one planned release change.
+
+## Verification Checklist
+
+- TS contracts updated in canonical package (`@anarchitects/forms-ts` or `@anarchitects/auth-ts`).
+- Nest route schemas import canonical contracts (no inline schema drift).
+- OpenAPI regenerated and reviewed for compatibility impact.
+- Angular contract consumers updated and tested.
+- Docs refreshed and validated:
+  `yarn nx run docs-hub:validate-content`,
+  `yarn nx run docs-hub:build`,
+  `yarn nx run docs-hub:verify`.

--- a/tools/docs-hub/build.mjs
+++ b/tools/docs-hub/build.mjs
@@ -9,6 +9,7 @@ const angularGuidePath = join(workspaceRoot, 'docs/guides/angular.md');
 const nestGuidePath = join(workspaceRoot, 'docs/guides/nest.md');
 const aiAgentsGuidePath = join(workspaceRoot, 'docs/guides/ai-agents.md');
 const designUiSystemsGuidePath = join(workspaceRoot, 'docs/guides/design-ui-systems.md');
+const tsContractsGuidePath = join(workspaceRoot, 'docs/guides/ts-contracts.md');
 
 marked.setOptions({
   gfm: true,
@@ -38,6 +39,7 @@ function pageTemplate(title, activePath, content, generatedAt) {
     { href: '/packages/', label: 'Packages' },
     { href: '/guides/angular.html', label: 'Angular Guide' },
     { href: '/guides/nest.html', label: 'Nest Guide' },
+    { href: '/guides/ts-contracts.html', label: 'TS Contracts Guide' },
     { href: '/guides/design-ui-systems.html', label: 'Design/UI Systems Guide' },
     { href: '/guides/ai-agents.html', label: 'AI Agents Guide' },
     { href: '/release/', label: 'Release' },
@@ -186,6 +188,7 @@ const angularGuideMarkdown = readFileSync(angularGuidePath, 'utf8');
 const nestGuideMarkdown = readFileSync(nestGuidePath, 'utf8');
 const aiAgentsGuideMarkdown = readFileSync(aiAgentsGuidePath, 'utf8');
 const designUiSystemsGuideMarkdown = readFileSync(designUiSystemsGuidePath, 'utf8');
+const tsContractsGuideMarkdown = readFileSync(tsContractsGuidePath, 'utf8');
 
 rmSync(outputRoot, { recursive: true, force: true });
 ensureDir(join(outputRoot, 'assets'));
@@ -239,6 +242,7 @@ writeFile(
     <li><a href="/packages/">Publishable package catalog</a></li>
     <li><a href="/guides/angular.html">Angular application guide</a></li>
     <li><a href="/guides/nest.html">Nest application guide</a></li>
+    <li><a href="/guides/ts-contracts.html">TS contracts guide</a></li>
     <li><a href="/guides/design-ui-systems.html">Design/UI systems guide</a></li>
     <li><a href="/guides/ai-agents.html">AI coding agents templates</a></li>
     <li><a href="/release/">Release and versioning guidance</a></li>
@@ -300,6 +304,16 @@ writeFile(
 );
 
 writeFile(
+  'guides/ts-contracts.html',
+  renderMarkdownPage(
+    'TS Contracts Guide',
+    '/guides/ts-contracts.html',
+    tsContractsGuideMarkdown,
+    generatedAt,
+  ),
+);
+
+writeFile(
   'guides/ai-agents.html',
   renderMarkdownPage(
     'AI Agents Guide',
@@ -341,6 +355,7 @@ writeFile(
 writeFile('data/packages.catalog.json', `${JSON.stringify(catalog, null, 2)}\n`);
 writeFile('guides/angular.md', angularGuideMarkdown);
 writeFile('guides/nest.md', nestGuideMarkdown);
+writeFile('guides/ts-contracts.md', tsContractsGuideMarkdown);
 writeFile('guides/ai-agents.md', aiAgentsGuideMarkdown);
 writeFile('guides/design-ui-systems.md', designUiSystemsGuideMarkdown);
 

--- a/tools/docs-hub/validate-content.mjs
+++ b/tools/docs-hub/validate-content.mjs
@@ -6,6 +6,7 @@ const libsRoot = join(workspaceRoot, 'libs');
 const guideFiles = [
   { path: 'docs/guides/angular.md', key: 'angular' },
   { path: 'docs/guides/nest.md', key: 'nest' },
+  { path: 'docs/guides/ts-contracts.md', key: 'tsContracts' },
   { path: 'docs/guides/design-ui-systems.md', key: 'designUiSystems' },
   { path: 'docs/guides/ai-agents.md', key: 'aiAgents' },
 ];
@@ -14,14 +15,10 @@ const guideRequirements = {
   angular: [
     'intent',
     'architecture',
-    'design system foundations',
-    'quick start with design ui stack',
-    'theme and token customization',
-    'ui composition and primitives',
-    'composition cookbook',
-    'layout runtime',
+    'easy mode with root exports',
+    'advanced mode with secondary entry points',
+    'ts contract integration',
     'layout cookbook',
-    'app composition',
     'state data access',
     'testing and docs workflow',
     'common pitfalls',
@@ -29,17 +26,24 @@ const guideRequirements = {
   nest: [
     'intent',
     'architecture',
-    'module composition',
-    'configuration',
-    'ui contract support',
-    'contract design for ui consumers',
+    'easy mode with composition modules',
+    'advanced mode with layer entry points',
+    'ts contract integration',
+    'library entry point cookbook',
     'schema evolution and compatibility',
-    'forms and auth contract mapping',
-    'infrastructure boundaries',
-    'design ui system aware api evolution',
-    'cookbook for ui impacting backend changes',
     'contract verification workflow',
     'common pitfalls',
+  ],
+  tsContracts: [
+    'intent',
+    'contract ownership model',
+    'domain contract matrix',
+    'forms ts contracts',
+    'auth ts contracts',
+    'consumer mapping angular and nest',
+    'contract change workflow',
+    'compatibility rules',
+    'verification checklist',
   ],
   designUiSystems: [
     'intent',
@@ -105,7 +109,7 @@ const aiGuideRequiredBlocks = [
   },
 ];
 
-const crossGuideDesignUiCoverageTokens = [
+const designUiSystemsRequiredTokens = [
   '@anarchitects/common-angular-design',
   '@anarchitects/common-angular-ui-composition',
   '@anarchitects/common-angular-ui-primitives',
@@ -114,6 +118,31 @@ const crossGuideDesignUiCoverageTokens = [
   '@anarchitects/auth-angular',
   'ui <- feature -> state -> data-access',
   'presentation -> application <- infrastructure',
+];
+
+const requiredDesignGuideLink = '/guides/design-ui-systems.html';
+const requiredTsGuideLink = '/guides/ts-contracts.html';
+const forbiddenSharedHeadingsInFrameworkGuides = [
+  'system layers',
+  'token and theme model',
+  'composition contracts',
+  'primitive contracts',
+  'layout runtime contracts',
+  'domain integration matrix',
+];
+const forbiddenTsCanonicalHeadingsInFrameworkGuides = [
+  'contract ownership model',
+  'domain contract matrix',
+  'forms ts contracts',
+  'auth ts contracts',
+];
+const tsContractsRequiredTokens = [
+  '@anarchitects/forms-ts',
+  '@anarchitects/auth-ts',
+  '@anarchitects/forms-angular',
+  '@anarchitects/auth-angular',
+  '@anarchitects/forms-nest',
+  '@anarchitects/auth-nest',
 ];
 
 function walkFiles(rootDir, targetName) {
@@ -253,21 +282,70 @@ for (const guide of guideFiles) {
       );
     }
   }
+
+  if (guide.key === 'angular' || guide.key === 'nest') {
+    const normalizedMarkdown = markdownContent.toLowerCase();
+    if (!normalizedMarkdown.includes(requiredDesignGuideLink)) {
+      failures.push(
+        `${guide.path}: missing required canonical guide link ("${requiredDesignGuideLink}").`,
+      );
+    }
+    if (!normalizedMarkdown.includes(requiredTsGuideLink)) {
+      failures.push(
+        `${guide.path}: missing required canonical guide link ("${requiredTsGuideLink}").`,
+      );
+    }
+
+    const duplicatedSharedHeadings = forbiddenSharedHeadingsInFrameworkGuides
+      .filter((heading) => headings.includes(heading))
+      .map((heading) => `"${heading}"`);
+
+    if (duplicatedSharedHeadings.length > 0) {
+      failures.push(
+        `${guide.path}: contains forbidden duplicated shared headings -> ${duplicatedSharedHeadings.join(', ')}`,
+      );
+    }
+
+    const duplicatedTsCanonicalHeadings = forbiddenTsCanonicalHeadingsInFrameworkGuides
+      .filter((heading) => headings.includes(heading))
+      .map((heading) => `"${heading}"`);
+
+    if (duplicatedTsCanonicalHeadings.length > 0) {
+      failures.push(
+        `${guide.path}: contains forbidden duplicated TS-canonical headings -> ${duplicatedTsCanonicalHeadings.join(', ')}`,
+      );
+    }
+  }
+
+  if (guide.key === 'designUiSystems') {
+    const normalizedMarkdown = markdownContent.toLowerCase();
+    if (!normalizedMarkdown.includes(requiredTsGuideLink)) {
+      failures.push(
+        `${guide.path}: missing required link to TS contracts guide ("${requiredTsGuideLink}").`,
+      );
+    }
+  }
 }
 
-const coverageSources = ['angular', 'nest', 'designUiSystems'];
-const combinedGuideContent = coverageSources
-  .map((key) => guideContents.get(key) ?? '')
-  .join('\n')
-  .toLowerCase();
-
-const missingCoverageTokens = crossGuideDesignUiCoverageTokens
-  .filter((token) => !combinedGuideContent.includes(token.toLowerCase()))
+const designUiSystemsContent = (guideContents.get('designUiSystems') ?? '').toLowerCase();
+const missingCoverageTokens = designUiSystemsRequiredTokens
+  .filter((token) => !designUiSystemsContent.includes(token.toLowerCase()))
   .map((token) => `"${token}"`);
 
 if (missingCoverageTokens.length > 0) {
   failures.push(
-    `docs/guides/{angular,nest,design-ui-systems}.md: missing required design/ui coverage tokens -> ${missingCoverageTokens.join(', ')}`,
+    `docs/guides/design-ui-systems.md: missing required canonical design/ui coverage tokens -> ${missingCoverageTokens.join(', ')}`,
+  );
+}
+
+const tsContractsContent = (guideContents.get('tsContracts') ?? '').toLowerCase();
+const missingTsCoverageTokens = tsContractsRequiredTokens
+  .filter((token) => !tsContractsContent.includes(token.toLowerCase()))
+  .map((token) => `"${token}"`);
+
+if (missingTsCoverageTokens.length > 0) {
+  failures.push(
+    `docs/guides/ts-contracts.md: missing required canonical TS coverage tokens -> ${missingTsCoverageTokens.join(', ')}`,
   );
 }
 

--- a/tools/docs-hub/verify.mjs
+++ b/tools/docs-hub/verify.mjs
@@ -9,6 +9,7 @@ const requiredFiles = [
   'packages/index.html',
   'guides/angular.html',
   'guides/nest.html',
+  'guides/ts-contracts.html',
   'guides/design-ui-systems.html',
   'guides/ai-agents.html',
   'release/index.html',
@@ -59,6 +60,7 @@ const homePage = readFileSync(join(docsRoot, 'index.html'), 'utf8');
 if (
   !homePage.includes('/storybook/') ||
   !homePage.includes('/openapi/openapi.yaml') ||
+  !homePage.includes('/guides/ts-contracts.html') ||
   !homePage.includes('/guides/design-ui-systems.html') ||
   !homePage.includes('/guides/ai-agents.html')
 ) {


### PR DESCRIPTION
- add canonical TS contracts guide and publish it in docs hub
- reframe Angular guide around easy root exports vs advanced entry points
- reframe Nest guide around easy composition modules vs advanced layer entry points
- link Angular/Nest/Design-UI guides to canonical TS + design/UI references
- extend docs-hub build/verify to include /guides/ts-contracts.html
- tighten docs validator for required headings, cross-links, and de-dup guards