### PR TITLE
feat(forms): add reusable cross-field validation rules across ts, angular, and nest

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -634,7 +634,247 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "config": {},
+                    "config": {
+                      "properties": {
+                        "delivery": {
+                          "properties": {
+                            "adminEmail": {
+                              "format": "email",
+                              "type": "string"
+                            },
+                            "autoReply": {
+                              "properties": {
+                                "enabled": {
+                                  "type": "boolean"
+                                },
+                                "subject": {
+                                  "type": "string"
+                                },
+                                "templateId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "enabled",
+                                "templateId",
+                                "subject"
+                              ],
+                              "type": "object"
+                            },
+                            "subject": {
+                              "type": "string"
+                            },
+                            "templateId": {
+                              "type": "string"
+                            },
+                            "webhooks": {
+                              "items": {
+                                "properties": {
+                                  "secret": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "format": "uri",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fields": {
+                          "items": {
+                            "properties": {
+                              "kind": {
+                                "anyOf": [
+                                  {
+                                    "enum": [
+                                      "string"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "password"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "email"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "textarea"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "boolean"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "select"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  {
+                                    "enum": [
+                                      "file"
+                                    ],
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "maxLength": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "minLength": {
+                                "minimum": 0,
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "items": {
+                                  "properties": {
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "label"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "pattern": {
+                                "type": "string"
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "ui": {
+                                "properties": {
+                                  "help": {
+                                    "type": "string"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "placeholder": {
+                                    "type": "string"
+                                  },
+                                  "rows": {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "kind"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "security": {
+                          "properties": {
+                            "captcha": {
+                              "anyOf": [
+                                {
+                                  "enum": [
+                                    "turnstile"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "enum": [
+                                    "hcaptcha"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "enum": [
+                                    "none"
+                                  ],
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "honeypot": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "captcha"
+                          ],
+                          "type": "object"
+                        },
+                        "validationRules": {
+                          "items": {
+                            "properties": {
+                              "kind": {
+                                "enum": [
+                                  "matchFields"
+                                ],
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "sourceField": {
+                                "type": "string"
+                              },
+                              "targetField": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "sourceField",
+                              "targetField"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "version": {
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "version",
+                        "fields"
+                      ],
+                      "type": "object"
+                    },
                     "schema": {}
                   },
                   "required": [

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -409,7 +409,157 @@ paths:
             application/json:
               schema:
                 properties:
-                  config: {}
+                  config:
+                    properties:
+                      delivery:
+                        properties:
+                          adminEmail:
+                            format: email
+                            type: string
+                          autoReply:
+                            properties:
+                              enabled:
+                                type: boolean
+                              subject:
+                                type: string
+                              templateId:
+                                type: string
+                            required:
+                              - enabled
+                              - templateId
+                              - subject
+                            type: object
+                          subject:
+                            type: string
+                          templateId:
+                            type: string
+                          webhooks:
+                            items:
+                              properties:
+                                secret:
+                                  type: string
+                                url:
+                                  format: uri
+                                  type: string
+                              required:
+                                - url
+                              type: object
+                            type: array
+                        type: object
+                      fields:
+                        items:
+                          properties:
+                            kind:
+                              anyOf:
+                                - enum:
+                                    - string
+                                  type: string
+                                - enum:
+                                    - password
+                                  type: string
+                                - enum:
+                                    - email
+                                  type: string
+                                - enum:
+                                    - textarea
+                                  type: string
+                                - enum:
+                                    - boolean
+                                  type: string
+                                - enum:
+                                    - select
+                                  type: string
+                                - enum:
+                                    - file
+                                  type: string
+                            maxLength:
+                              minimum: 0
+                              type: integer
+                            minLength:
+                              minimum: 0
+                              type: integer
+                            name:
+                              type: string
+                            options:
+                              items:
+                                properties:
+                                  label:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                  - value
+                                  - label
+                                type: object
+                              type: array
+                            pattern:
+                              type: string
+                            required:
+                              type: boolean
+                            ui:
+                              properties:
+                                help:
+                                  type: string
+                                label:
+                                  type: string
+                                placeholder:
+                                  type: string
+                                rows:
+                                  minimum: 1
+                                  type: integer
+                              type: object
+                          required:
+                            - name
+                            - kind
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      security:
+                        properties:
+                          captcha:
+                            anyOf:
+                              - enum:
+                                  - turnstile
+                                type: string
+                              - enum:
+                                  - hcaptcha
+                                type: string
+                              - enum:
+                                  - none
+                                type: string
+                          honeypot:
+                            type: string
+                        required:
+                          - captcha
+                        type: object
+                      validationRules:
+                        items:
+                          properties:
+                            kind:
+                              enum:
+                                - matchFields
+                              type: string
+                            message:
+                              type: string
+                            sourceField:
+                              type: string
+                            targetField:
+                              type: string
+                          required:
+                            - kind
+                            - sourceField
+                            - targetField
+                          type: object
+                        type: array
+                      version:
+                        minimum: 1
+                        type: integer
+                    required:
+                      - id
+                      - version
+                      - fields
+                    type: object
                   schema: {}
                 required:
                   - config

--- a/libs/forms/angular/ui/README.md
+++ b/libs/forms/angular/ui/README.md
@@ -12,6 +12,10 @@ Presentational domain UI components for `@anarchitects/forms-angular`.
 These components are layout-compatible (`anarchitects-ui-layout-host`) and support
 template overrides via canonical `ng-template[anxTemplate]` contracts.
 
+`AnarchitectsUiForm` supports declarative cross-field rules through
+`config.validationRules` and local-only Angular `runtimeValidators` for host-specific
+`ValidatorFn` composition that should not become part of the shared form contract.
+
 ## License
 
 Released under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/libs/forms/angular/ui/src/form.spec.ts
+++ b/libs/forms/angular/ui/src/form.spec.ts
@@ -1,13 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnarchitectsUiForm } from './form';
 import { ComponentRef } from '@angular/core';
+import { ValidatorFn } from '@angular/forms';
+import { FormConfig } from '@anarchitects/forms-ts/models';
 
 describe('Form', () => {
   let component: AnarchitectsUiForm;
   let fixture: ComponentFixture<AnarchitectsUiForm>;
   let ref: ComponentRef<AnarchitectsUiForm>;
 
-  const mockFormConfig = {
+  const mockFormConfig: FormConfig = {
     id: 'test-form',
     version: 1,
     fields: [
@@ -60,7 +62,7 @@ describe('Form', () => {
   it('should render password fields with type password', () => {
     const nativeElement = fixture.nativeElement as HTMLElement;
     const passwordInput = nativeElement.querySelector(
-      'input#password'
+      'input#password',
     ) as HTMLInputElement | null;
     expect(passwordInput).toBeTruthy();
     expect(passwordInput?.type).toBe('password');
@@ -96,5 +98,139 @@ describe('Form', () => {
     expect(component.formGroup.valid).toBe(false);
     component.onSubmit();
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should keep the form invalid when matchFields validation fails', () => {
+    const config: FormConfig = {
+      id: 'register',
+      version: 1,
+      fields: [
+        {
+          name: 'password',
+          kind: 'password',
+          minLength: 6,
+          required: true,
+          ui: { label: 'Password' },
+        },
+        {
+          name: 'confirmPassword',
+          kind: 'password',
+          minLength: 6,
+          required: true,
+          ui: { label: 'Confirm Password' },
+        },
+      ],
+      validationRules: [
+        {
+          kind: 'matchFields',
+          sourceField: 'password',
+          targetField: 'confirmPassword',
+          message: 'Passwords must match.',
+        },
+      ],
+    };
+
+    ref.setInput('config', config);
+    fixture.detectChanges();
+
+    component.formGroup.setValue({
+      password: 'secret123',
+      confirmPassword: 'secret124',
+    });
+    component.formGroup.get('confirmPassword')?.markAsTouched();
+    fixture.detectChanges();
+
+    expect(component.formGroup.invalid).toBe(true);
+    expect(component.fieldErrorMessage('confirmPassword')).toBe(
+      'Passwords must match.',
+    );
+  });
+
+  it('should clear cross-field errors once fields match', () => {
+    const config: FormConfig = {
+      id: 'register',
+      version: 1,
+      fields: [
+        { name: 'password', kind: 'password', minLength: 6, required: true },
+        {
+          name: 'confirmPassword',
+          kind: 'password',
+          minLength: 6,
+          required: true,
+        },
+      ],
+      validationRules: [
+        {
+          kind: 'matchFields',
+          sourceField: 'password',
+          targetField: 'confirmPassword',
+          message: 'Passwords must match.',
+        },
+      ],
+    };
+
+    ref.setInput('config', config);
+    fixture.detectChanges();
+
+    component.formGroup.setValue({
+      password: 'secret123',
+      confirmPassword: 'secret124',
+    });
+    component.formGroup.get('confirmPassword')?.markAsTouched();
+    fixture.detectChanges();
+
+    component.formGroup.patchValue({ confirmPassword: 'secret123' });
+    fixture.detectChanges();
+
+    expect(component.formGroup.valid).toBe(true);
+    expect(component.fieldErrorMessage('confirmPassword')).toBeNull();
+  });
+
+  it('should compose runtime validators with declarative validation rules', () => {
+    const config: FormConfig = {
+      id: 'register',
+      version: 1,
+      fields: [
+        { name: 'email', kind: 'email', required: true },
+        { name: 'password', kind: 'password', minLength: 6, required: true },
+        {
+          name: 'confirmPassword',
+          kind: 'password',
+          minLength: 6,
+          required: true,
+        },
+      ],
+      validationRules: [
+        {
+          kind: 'matchFields',
+          sourceField: 'password',
+          targetField: 'confirmPassword',
+          message: 'Passwords must match.',
+        },
+      ],
+    };
+    const runtimeValidator: ValidatorFn = (control) =>
+      control.get('email')?.value === 'blocked@example.com'
+        ? { runtimeBlocked: true }
+        : null;
+
+    ref.setInput('config', config);
+    ref.setInput('runtimeValidators', [runtimeValidator]);
+    fixture.detectChanges();
+
+    component.formGroup.setValue({
+      email: 'blocked@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret124',
+    });
+    fixture.detectChanges();
+
+    expect(component.formGroup.hasError('runtimeBlocked')).toBe(true);
+    expect(component.formGroup.errors?.['crossField']).toEqual({
+      confirmPassword: {
+        kind: 'matchFields',
+        message: 'Passwords must match.',
+      },
+    });
   });
 });

--- a/libs/forms/angular/ui/src/form.stories.ts
+++ b/libs/forms/angular/ui/src/form.stories.ts
@@ -2,6 +2,7 @@ import { FormConfig } from '@anarchitects/forms-ts';
 import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-composition/templates';
 import { moduleMetadata } from '@storybook/angular';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { ValidatorFn } from '@angular/forms';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import { AnarchitectsUiForm } from './form';
 
@@ -61,6 +62,44 @@ const mockFormConfig: FormConfig = {
     },
   ],
 };
+
+const passwordValidationConfig: FormConfig = {
+  id: 'register-form',
+  version: 1,
+  fields: [
+    {
+      name: 'password',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: {
+        label: 'Password',
+      },
+    },
+    {
+      name: 'confirmPassword',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: {
+        label: 'Confirm Password',
+      },
+    },
+  ],
+  validationRules: [
+    {
+      kind: 'matchFields',
+      sourceField: 'password',
+      targetField: 'confirmPassword',
+      message: 'Passwords must match.',
+    },
+  ],
+};
+
+const blockedEmailValidator: ValidatorFn = (control) =>
+  control.get('email')?.value === 'blocked@example.com'
+    ? { runtimeBlocked: true }
+    : null;
 
 export const Primary: Story = {
   args: {
@@ -162,5 +201,47 @@ export const SuccessfulSubmitResetsFields: Story = {
       expect(messageInput.value).toBe('');
       expect(consentCheckbox.checked).toBe(false);
     });
+  },
+};
+
+export const CrossFieldValidation: Story = {
+  args: {
+    config: passwordValidationConfig,
+  },
+  play: async ({ canvas }) => {
+    await userEvent.type(
+      await canvas.findByLabelText(/^password$/i),
+      'secret123',
+    );
+    await userEvent.type(
+      await canvas.findByLabelText(/confirm password/i),
+      'secret124',
+    );
+
+    expect(await canvas.findByText(/passwords must match/i)).toBeTruthy();
+  },
+};
+
+export const RuntimeValidators: Story = {
+  args: {
+    config: mockFormConfig,
+    runtimeValidators: [blockedEmailValidator],
+  },
+  play: async ({ canvas }) => {
+    await userEvent.type(await canvas.findByLabelText(/name/i), 'Jane Doe');
+    await userEvent.type(
+      await canvas.findByLabelText(/email/i),
+      'blocked@example.com',
+    );
+    await userEvent.type(
+      await canvas.findByLabelText(/message/i),
+      'Hello from Storybook',
+    );
+    await userEvent.click(
+      await canvas.findByRole('checkbox', { name: /consent/i }),
+    );
+
+    const submitButton = await canvas.findByRole('button', { name: /submit/i });
+    expect((submitButton as HTMLButtonElement).disabled).toBe(true);
   },
 };

--- a/libs/forms/angular/ui/src/form.ts
+++ b/libs/forms/angular/ui/src/form.ts
@@ -1,5 +1,9 @@
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
+import {
+  FormConfig,
+  FormField,
+  FormValidationRule,
+} from '@anarchitects/forms-ts/models';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
@@ -10,7 +14,14 @@ import {
   input,
   output,
 } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
 import { AnarchitectsUiButton } from '@anarchitects/common-angular-ui-primitives/actions';
 import {
   AnarchitectsUiField,
@@ -23,6 +34,67 @@ import { AnxTemplateDirective } from '@anarchitects/common-angular-ui-compositio
 import { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
 import { provideAnxDefaultLayouts } from '@anarchitects/common-angular-ui-layouts/defaults';
 import { AnarchitectsUiLayoutHost } from '@anarchitects/common-angular-ui-layouts/host';
+
+type CrossFieldError = {
+  kind: string;
+  message: string;
+};
+
+type CrossFieldErrors = Record<string, CrossFieldError>;
+
+function buildFieldValidators(field: FormField): ValidatorFn[] {
+  const validators: ValidatorFn[] = [];
+
+  if (field.required) {
+    validators.push(Validators.required);
+  }
+  if (field.minLength) {
+    validators.push(Validators.minLength(field.minLength));
+  }
+  if (field.maxLength) {
+    validators.push(Validators.maxLength(field.maxLength));
+  }
+  if (field.kind === 'email') {
+    validators.push(Validators.email);
+  }
+
+  return validators;
+}
+
+function buildConfigValidator(
+  rules: readonly FormValidationRule[] | undefined,
+): ValidatorFn | null {
+  if (!rules?.length) {
+    return null;
+  }
+
+  return (control: AbstractControl): ValidationErrors | null => {
+    const crossField: CrossFieldErrors = {};
+
+    for (const rule of rules) {
+      if (rule.kind !== 'matchFields') {
+        continue;
+      }
+
+      const sourceControl = control.get(rule.sourceField);
+      const targetControl = control.get(rule.targetField);
+      if (!sourceControl || !targetControl) {
+        continue;
+      }
+
+      if (sourceControl.value === targetControl.value) {
+        continue;
+      }
+
+      crossField[rule.targetField] = {
+        kind: rule.kind,
+        message: rule.message ?? 'Fields must match.',
+      };
+    }
+
+    return Object.keys(crossField).length > 0 ? { crossField } : null;
+  };
+}
 
 @Component({
   selector: 'anarchitects-forms-ui-form',
@@ -51,6 +123,7 @@ export class AnarchitectsUiForm {
   private readonly fb = inject(FormBuilder);
   readonly formGroup = this.fb.group({});
   readonly config = input.required<FormConfig>();
+  readonly runtimeValidators = input<readonly ValidatorFn[]>([]);
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<SubmissionRequestDTO>();
@@ -63,29 +136,52 @@ export class AnarchitectsUiForm {
   constructor() {
     effect(() => {
       const config = this.config();
-      if (config) {
-        this.formGroup.reset();
-        this.formGroup.clearValidators();
-        this.formGroup.clearAsyncValidators();
-        this.formGroup.updateValueAndValidity();
-        for (const f of config.fields) {
-          const v = [];
-          if (f.required) {
-            v.push(Validators.required);
-          }
-          if (f.minLength) {
-            v.push(Validators.minLength(f.minLength));
-          }
-          if (f.maxLength) {
-            v.push(Validators.maxLength(f.maxLength));
-          }
-          if (f.kind === 'email') {
-            v.push(Validators.email);
-          }
-          this.formGroup.addControl(f.name, this.fb.control(null, v));
-        }
+
+      for (const fieldName of Object.keys(this.formGroup.controls)) {
+        this.formGroup.removeControl(fieldName);
       }
+
+      for (const field of config.fields) {
+        this.formGroup.addControl(
+          field.name,
+          this.fb.control(null, buildFieldValidators(field)),
+        );
+      }
+
+      this.formGroup.reset();
+      this.formGroup.updateValueAndValidity({ emitEvent: false });
     });
+
+    effect(() => {
+      const configValidator = buildConfigValidator(
+        this.config().validationRules,
+      );
+      const validators = [
+        ...(configValidator ? [configValidator] : []),
+        ...this.runtimeValidators(),
+      ];
+
+      this.formGroup.setValidators(validators.length > 0 ? validators : null);
+      this.formGroup.updateValueAndValidity({ emitEvent: false });
+    });
+  }
+
+  private crossFieldError(fieldName: string): CrossFieldError | null {
+    const errors = this.formGroup.errors?.['crossField'] as
+      | CrossFieldErrors
+      | undefined;
+
+    return errors?.[fieldName] ?? null;
+  }
+
+  private shouldShowCrossFieldError(fieldName: string): boolean {
+    const control = this.formGroup.get(fieldName);
+
+    return Boolean(
+      control &&
+        this.crossFieldError(fieldName) &&
+        (control.touched || control.dirty),
+    );
   }
 
   fieldId(fieldName: string): string {
@@ -94,34 +190,44 @@ export class AnarchitectsUiForm {
 
   fieldErrorMessage(fieldName: string): string | null {
     const control = this.formGroup.get(fieldName);
-    if (!control || !control.touched || !control.invalid) {
+    if (!control) {
       return null;
     }
 
-    if (control.hasError('required')) {
-      return 'This field is required.';
+    if (control.touched && control.invalid) {
+      if (control.hasError('required')) {
+        return 'This field is required.';
+      }
+
+      if (control.hasError('email')) {
+        return 'Enter a valid email address.';
+      }
+
+      if (control.hasError('minlength')) {
+        const requiredLength = control.getError('minlength')?.requiredLength;
+        return `Minimum length is ${requiredLength}.`;
+      }
+
+      if (control.hasError('maxlength')) {
+        const requiredLength = control.getError('maxlength')?.requiredLength;
+        return `Maximum length is ${requiredLength}.`;
+      }
+
+      return 'Invalid value.';
     }
 
-    if (control.hasError('email')) {
-      return 'Enter a valid email address.';
-    }
-
-    if (control.hasError('minlength')) {
-      const requiredLength = control.getError('minlength')?.requiredLength;
-      return `Minimum length is ${requiredLength}.`;
-    }
-
-    if (control.hasError('maxlength')) {
-      const requiredLength = control.getError('maxlength')?.requiredLength;
-      return `Maximum length is ${requiredLength}.`;
-    }
-
-    return 'Invalid value.';
+    return this.shouldShowCrossFieldError(fieldName)
+      ? (this.crossFieldError(fieldName)?.message ?? null)
+      : null;
   }
 
   isFieldInvalid(fieldName: string): boolean {
     const control = this.formGroup.get(fieldName);
-    return Boolean(control && control.touched && control.invalid);
+
+    return Boolean(
+      (control && control.touched && control.invalid) ||
+        this.shouldShowCrossFieldError(fieldName),
+    );
   }
 
   onSubmit() {

--- a/libs/forms/nest/src/application/services/forms.service.spec.ts
+++ b/libs/forms/nest/src/application/services/forms.service.spec.ts
@@ -17,6 +17,14 @@ describe('FormsService', () => {
         required: true,
       },
     ],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   };
 
   const mockFormConfigsRepository = {
@@ -47,6 +55,9 @@ describe('FormsService', () => {
       expect(result).toHaveProperty('config');
       expect(result).toHaveProperty('schema');
       expect(result.config).toEqual(mockFormConfig);
+      expect(result.config.validationRules).toEqual(
+        mockFormConfig.validationRules,
+      );
       expect(mockFormConfigsRepository.getFormConfig).toHaveBeenCalledWith(
         'contact_default',
         1,

--- a/libs/forms/nest/src/infrastructure-persistence/entities/form-config.entity.spec.ts
+++ b/libs/forms/nest/src/infrastructure-persistence/entities/form-config.entity.spec.ts
@@ -6,6 +6,14 @@ describe('FormConfigEntity', () => {
     id: faker.string.alphanumeric(12),
     version: 1,
     fields: [{ name: 'email', kind: 'email' as const, required: true }],
+    validationRules: [
+      {
+        kind: 'matchFields' as const,
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
     security: { captcha: 'none' as const },
   };
 

--- a/libs/forms/nest/src/infrastructure-persistence/entities/form-config.entity.ts
+++ b/libs/forms/nest/src/infrastructure-persistence/entities/form-config.entity.ts
@@ -14,6 +14,9 @@ export class FormConfigEntity implements FormConfig {
   fields!: FormConfig['fields'];
 
   @Column({ type: 'jsonb', nullable: true })
+  validationRules?: FormConfig['validationRules'];
+
+  @Column({ type: 'jsonb', nullable: true })
   security?: FormConfig['security'];
 
   @Column({ type: 'jsonb', nullable: true })

--- a/libs/forms/nest/src/infrastructure-persistence/migrations/1720310000000-add-validation-rules-to-form-configs.ts
+++ b/libs/forms/nest/src/infrastructure-persistence/migrations/1720310000000-add-validation-rules-to-form-configs.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { FORMS_SCHEMA } from '../schema';
+
+const FORM_CONFIGS_TABLE = `${FORMS_SCHEMA}.form_configs`;
+const VALIDATION_RULES_COLUMN = 'validationRules';
+
+export class AddValidationRulesToFormConfigs1720310000000
+  implements MigrationInterface
+{
+  name = 'AddValidationRulesToFormConfigs1720310000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable(FORM_CONFIGS_TABLE);
+    const hasColumn = table?.findColumnByName(VALIDATION_RULES_COLUMN);
+
+    if (!hasColumn) {
+      await queryRunner.addColumn(
+        FORM_CONFIGS_TABLE,
+        new TableColumn({
+          name: VALIDATION_RULES_COLUMN,
+          type: 'jsonb',
+          isNullable: true,
+        }),
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable(FORM_CONFIGS_TABLE);
+    const hasColumn = table?.findColumnByName(VALIDATION_RULES_COLUMN);
+
+    if (hasColumn) {
+      await queryRunner.dropColumn(FORM_CONFIGS_TABLE, VALIDATION_RULES_COLUMN);
+    }
+  }
+}

--- a/libs/forms/nest/src/infrastructure-persistence/repositories/typeorm-form-configs.repository.spec.ts
+++ b/libs/forms/nest/src/infrastructure-persistence/repositories/typeorm-form-configs.repository.spec.ts
@@ -12,6 +12,14 @@ describe('TypeOrmFormConfigsRepository', () => {
     id: 'contact_default',
     version: 1,
     fields: [{ name: 'email', kind: 'email', required: true }],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   };
 
   const mockRepository = {

--- a/libs/forms/nest/src/presentation/controllers/forms.controller.spec.ts
+++ b/libs/forms/nest/src/presentation/controllers/forms.controller.spec.ts
@@ -14,6 +14,14 @@ describe('FormsController', () => {
       { name: 'test', kind: 'string' as const },
       { name: 'email', kind: 'email' as const },
     ],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   };
 
   const mockFormDefinitionEnvelope = {
@@ -50,7 +58,7 @@ describe('FormsController', () => {
       const result = await controller.getFormDefinition(formId, {
         formVersion: 2,
       });
-      expect(result).toBe(mockFormDefinitionEnvelope);
+      expect(result).toEqual(mockFormDefinitionEnvelope);
       expect(mockFormService.getDefinition).toHaveBeenCalledWith(formId, 2);
     });
 

--- a/libs/forms/nest/src/presentation/controllers/forms.controller.ts
+++ b/libs/forms/nest/src/presentation/controllers/forms.controller.ts
@@ -4,6 +4,7 @@ import {
   FormDefinitionQuerySchema,
   FormIdParamsSchema,
 } from '@anarchitects/forms-ts/dtos';
+import { toFormDefinitionEnvelopeResponseDTO } from '@anarchitects/forms-ts/mappers';
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { RouteSchema } from '@nestjs/platform-fastify';
 import { FormsService } from '../../application/services/forms.service';
@@ -24,6 +25,8 @@ export class FormsController {
     @Param('formId') formId: string,
     @Query() query: FormDefinitionQueryDTO,
   ) {
-    return this.formsService.getDefinition(formId, query?.formVersion ?? 1);
+    return this.formsService
+      .getDefinition(formId, query?.formVersion ?? 1)
+      .then((definition) => toFormDefinitionEnvelopeResponseDTO(definition));
   }
 }

--- a/libs/forms/ts/README.md
+++ b/libs/forms/ts/README.md
@@ -16,6 +16,7 @@ and generate runtime validation schemas automatically.
 - ⚡ **Runtime Schema Generation** - Automatically generate TypeBox schemas from form configs
 - 🔒 **Type Safety** - Full TypeScript support with inferred types
 - 🎯 **Field Validation** - Built-in support for strings, emails, textareas, booleans, selects, and file uploads
+- 🔁 **Cross-Field Validation Rules** - Declarative transport-safe rules such as password confirmation
 - 🛡️ **Security Features** - Honeypot and CAPTCHA integration options
 - 📧 **Delivery Configuration** - Email notifications and webhook support
 
@@ -148,10 +149,7 @@ console.log(errors); // []
 ### Using DTOs for API Integration
 
 ```typescript
-import {
-  FormDefinitionRequestDTO,
-  SubmissionRequestDTO,
-} from '@anarchitects/forms-ts/dtos';
+import { FormDefinitionRequestDTO, SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 
 // Request a form definition
 const formRequest: FormDefinitionRequestDTO = {
@@ -177,6 +175,14 @@ const submission: SubmissionRequestDTO = {
 ```typescript
 const secureForm: FormConfig = {
   // ... other config
+  validationRules: [
+    {
+      kind: 'matchFields',
+      sourceField: 'password',
+      targetField: 'confirmPassword',
+      message: 'Passwords must match.',
+    },
+  ],
   security: {
     honeypot: 'website', // Honeypot field name
     captcha: 'turnstile', // 'turnstile' | 'hcaptcha' | 'none'
@@ -237,19 +243,10 @@ The library provides subpath exports for better tree-shaking:
 import { FormConfig, FormField, contactForm } from '@anarchitects/forms-ts';
 
 // Models only
-import {
-  FormField,
-  FieldKind,
-  FormConfig,
-} from '@anarchitects/forms-ts/models';
+import { FormField, FieldKind, FormConfig } from '@anarchitects/forms-ts/models';
 
 // DTOs only
-import {
-  FormDefinitionRequestDTO,
-  FormDefinitionResponseDTO,
-  SubmissionRequestDTO,
-  SubmissionResponseDTO,
-} from '@anarchitects/forms-ts/dtos';
+import { FormDefinitionRequestDTO, FormDefinitionResponseDTO, SubmissionRequestDTO, SubmissionResponseDTO } from '@anarchitects/forms-ts/dtos';
 
 // Builders only
 import { schemaFromConfig } from '@anarchitects/forms-ts/builders';

--- a/libs/forms/ts/src/dtos/form-definition-envelope-response.dto.ts
+++ b/libs/forms/ts/src/dtos/form-definition-envelope-response.dto.ts
@@ -1,7 +1,8 @@
 import { Static, Type } from '@sinclair/typebox';
+import { FormDefinitionResponseSchema } from './form-definition-response.dto';
 
 export const FormDefinitionEnvelopeResponseSchema = Type.Object({
-  config: Type.Unknown(),
+  config: FormDefinitionResponseSchema,
   schema: Type.Unknown(),
 });
 

--- a/libs/forms/ts/src/dtos/form-definition-response.dto.spec.ts
+++ b/libs/forms/ts/src/dtos/form-definition-response.dto.spec.ts
@@ -41,8 +41,16 @@ const buildValidFormDefinitionResponse = (): FormDefinitionResponseDTO => ({
   version: faker.number.int({ min: 1, max: 100 }),
   fields: Array.from(
     { length: faker.number.int({ min: 1, max: 5 }) },
-    buildValidFormField
+    buildValidFormField,
   ),
+  validationRules: [
+    {
+      kind: 'matchFields',
+      sourceField: 'password',
+      targetField: 'confirmPassword',
+      message: 'Passwords must match.',
+    },
+  ],
   security: {
     honeypot: faker.lorem.word(),
     captcha: faker.helpers.arrayElement([
@@ -108,7 +116,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           id: 123,
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -117,7 +125,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           id: null,
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
   });
 
@@ -130,7 +138,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           version: 0,
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -139,7 +147,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           version: -1,
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -148,7 +156,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           version: 1.5,
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
   });
 
@@ -161,7 +169,7 @@ describe('FormDefinitionResponseSchema', () => {
           ...validResponse,
           fields: 'not-an-array',
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -175,7 +183,7 @@ describe('FormDefinitionResponseSchema', () => {
             },
           ],
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -189,7 +197,7 @@ describe('FormDefinitionResponseSchema', () => {
             },
           ],
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
   });
 
@@ -239,7 +247,7 @@ describe('FormDefinitionResponseSchema', () => {
             captcha: 'invalid-captcha',
           },
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect([
@@ -250,6 +258,52 @@ describe('FormDefinitionResponseSchema', () => {
         },
       }),
     ]).toStrictEqual([]);
+  });
+
+  it('validates optional cross-field validation rules', () => {
+    const validResponse = buildValidFormDefinitionResponse();
+
+    expect([
+      ...Value.Errors(FormDefinitionResponseSchema, {
+        ...validResponse,
+        validationRules: [
+          {
+            kind: 'matchFields',
+            sourceField: 'password',
+            targetField: 'confirmPassword',
+          },
+        ],
+      }),
+    ]).toStrictEqual([]);
+
+    expect(
+      [
+        ...Value.Errors(FormDefinitionResponseSchema, {
+          ...validResponse,
+          validationRules: [
+            {
+              kind: 'unknown',
+              sourceField: 'password',
+              targetField: 'confirmPassword',
+            },
+          ],
+        }),
+      ].length,
+    ).toBeGreaterThan(0);
+
+    expect(
+      [
+        ...Value.Errors(FormDefinitionResponseSchema, {
+          ...validResponse,
+          validationRules: [
+            {
+              kind: 'matchFields',
+              sourceField: 'password',
+            },
+          ],
+        }),
+      ].length,
+    ).toBeGreaterThan(0);
   });
 
   it('validates optional delivery configuration', () => {
@@ -263,7 +317,7 @@ describe('FormDefinitionResponseSchema', () => {
             adminEmail: 'invalid-email',
           },
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
 
     expect(
@@ -279,7 +333,7 @@ describe('FormDefinitionResponseSchema', () => {
             ],
           },
         }),
-      ].length
+      ].length,
     ).toBeGreaterThan(0);
   });
 
@@ -289,19 +343,19 @@ describe('FormDefinitionResponseSchema', () => {
     const missingId = { ...validResponse } as Record<string, unknown>;
     delete missingId['id'];
     expect(
-      [...Value.Errors(FormDefinitionResponseSchema, missingId)].length
+      [...Value.Errors(FormDefinitionResponseSchema, missingId)].length,
     ).toBeGreaterThan(0);
 
     const missingVersion = { ...validResponse } as Record<string, unknown>;
     delete missingVersion['version'];
     expect(
-      [...Value.Errors(FormDefinitionResponseSchema, missingVersion)].length
+      [...Value.Errors(FormDefinitionResponseSchema, missingVersion)].length,
     ).toBeGreaterThan(0);
 
     const missingFields = { ...validResponse } as Record<string, unknown>;
     delete missingFields['fields'];
     expect(
-      [...Value.Errors(FormDefinitionResponseSchema, missingFields)].length
+      [...Value.Errors(FormDefinitionResponseSchema, missingFields)].length,
     ).toBeGreaterThan(0);
   });
 });

--- a/libs/forms/ts/src/dtos/form-definition-response.dto.ts
+++ b/libs/forms/ts/src/dtos/form-definition-response.dto.ts
@@ -20,8 +20,8 @@ const formField = Type.Object({
       Type.Object({
         value: Type.String(),
         label: Type.String(),
-      })
-    )
+      }),
+    ),
   ),
   ui: Type.Optional(
     Type.Object({
@@ -29,13 +29,22 @@ const formField = Type.Object({
       placeholder: Type.Optional(Type.String()),
       rows: Type.Optional(Type.Integer({ minimum: 1 })),
       help: Type.Optional(Type.String()),
-    })
+    }),
   ),
 });
+
+const formValidationRule = Type.Object({
+  kind: Type.Literal('matchFields'),
+  sourceField: Type.String(),
+  targetField: Type.String(),
+  message: Type.Optional(Type.String()),
+});
+
 export const FormDefinitionResponseSchema = Type.Object({
   id: Type.String(),
   version: Type.Integer({ minimum: 1 }),
   fields: Type.Array(formField),
+  validationRules: Type.Optional(Type.Array(formValidationRule)),
   security: Type.Optional(
     Type.Object({
       honeypot: Type.Optional(Type.String()),
@@ -44,7 +53,7 @@ export const FormDefinitionResponseSchema = Type.Object({
         Type.Literal('hcaptcha'),
         Type.Literal('none'),
       ]),
-    })
+    }),
   ),
   delivery: Type.Optional(
     Type.Object({
@@ -56,17 +65,17 @@ export const FormDefinitionResponseSchema = Type.Object({
           enabled: Type.Boolean(),
           templateId: Type.String(),
           subject: Type.String(),
-        })
+        }),
       ),
       webhooks: Type.Optional(
         Type.Array(
           Type.Object({
             url: Type.String({ format: 'uri' }),
             secret: Type.Optional(Type.String()),
-          })
-        )
+          }),
+        ),
       ),
-    })
+    }),
   ),
 });
 

--- a/libs/forms/ts/src/mappers/form-config.mapper.spec.ts
+++ b/libs/forms/ts/src/mappers/form-config.mapper.spec.ts
@@ -1,0 +1,27 @@
+import { fromFormDefinitionResponseDTO, toFormDefinitionResponseDTO } from '.';
+import { FormConfig } from '../models';
+
+describe('form-config mapper', () => {
+  it('preserves validationRules through DTO round-trip', () => {
+    const model: FormConfig = {
+      id: 'register',
+      version: 1,
+      fields: [
+        { name: 'password', kind: 'password', required: true },
+        { name: 'confirmPassword', kind: 'password', required: true },
+      ],
+      validationRules: [
+        {
+          kind: 'matchFields',
+          sourceField: 'password',
+          targetField: 'confirmPassword',
+          message: 'Passwords must match.',
+        },
+      ],
+    };
+
+    const dto = toFormDefinitionResponseDTO(model);
+
+    expect(fromFormDefinitionResponseDTO(dto)).toEqual(model);
+  });
+});

--- a/libs/forms/ts/src/mappers/form-config.mapper.ts
+++ b/libs/forms/ts/src/mappers/form-config.mapper.ts
@@ -9,6 +9,7 @@ const cloneConfig = (config: FormConfig): FormConfig => ({
     options: field.options?.map((option) => ({ ...option })),
     ui: field.ui ? { ...field.ui } : undefined,
   })),
+  validationRules: config.validationRules?.map((rule) => ({ ...rule })),
   security: config.security ? { ...config.security } : undefined,
   delivery: config.delivery
     ? {

--- a/libs/forms/ts/src/models/form.types.ts
+++ b/libs/forms/ts/src/models/form.types.ts
@@ -18,10 +18,18 @@ export interface FormField {
   ui?: { label?: string; placeholder?: string; rows?: number; help?: string };
 }
 
+export type FormValidationRule = {
+  kind: 'matchFields';
+  sourceField: string;
+  targetField: string;
+  message?: string;
+};
+
 export interface FormConfig {
   id: string;
   version: number;
   fields: FormField[];
+  validationRules?: FormValidationRule[];
   security?: { honeypot?: string; captcha?: 'turnstile' | 'hcaptcha' | 'none' };
   delivery?: {
     adminEmail?: string;

--- a/libs/ts/frontend/data-access/src/lib/generated/api.types.ts
+++ b/libs/ts/frontend/data-access/src/lib/generated/api.types.ts
@@ -568,7 +568,55 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        config: unknown;
+                        config: {
+                            delivery?: {
+                                /** Format: email */
+                                adminEmail?: string;
+                                autoReply?: {
+                                    enabled: boolean;
+                                    subject: string;
+                                    templateId: string;
+                                };
+                                subject?: string;
+                                templateId?: string;
+                                webhooks?: {
+                                    secret?: string;
+                                    /** Format: uri */
+                                    url: string;
+                                }[];
+                            };
+                            fields: {
+                                kind: "string" | "password" | "email" | "textarea" | "boolean" | "select" | "file";
+                                maxLength?: number;
+                                minLength?: number;
+                                name: string;
+                                options?: {
+                                    label: string;
+                                    value: string;
+                                }[];
+                                pattern?: string;
+                                required?: boolean;
+                                ui?: {
+                                    help?: string;
+                                    label?: string;
+                                    placeholder?: string;
+                                    rows?: number;
+                                };
+                            }[];
+                            id: string;
+                            security?: {
+                                captcha: "turnstile" | "hcaptcha" | "none";
+                                honeypot?: string;
+                            };
+                            validationRules?: {
+                                /** @enum {string} */
+                                kind: "matchFields";
+                                message?: string;
+                                sourceField: string;
+                                targetField: string;
+                            }[];
+                            version: number;
+                        };
                         schema: unknown;
                     };
                 };


### PR DESCRIPTION
- add serializable FormConfig.validationRules with matchFields support
- compose declarative and runtime validators in forms-angular UI
- persist validationRules in forms-nest and expose them in the typed API response
- add migration, mapper coverage, and forms-domain tests/docs