### PR TITLE
feat(auth): adopt forms cross-field validation for password confirmation

### DIFF
--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
@@ -17,6 +17,17 @@ describe('AnarchitectsAuthUiChangePasswordForm', () => {
     await fixture.whenStable();
   });
 
+  it('should configure confirmPassword to match newPassword', () => {
+    expect(component.formConfig().validationRules).toEqual([
+      {
+        kind: 'matchFields',
+        sourceField: 'newPassword',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ]);
+  });
+
   it('should map submission payload to ChangePasswordRequestDTO', () => {
     let emitted: ChangePasswordRequestDTO | undefined;
     component.submitted.subscribe((value) => {

--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
@@ -53,6 +53,14 @@ export class AnarchitectsAuthUiChangePasswordForm {
         ui: { label: 'Confirm Password' },
       },
     ],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'newPassword',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   });
 
   onSubmitted(input: SubmissionRequestDTO): void {

--- a/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
@@ -21,6 +21,17 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should configure confirmPassword to match password', () => {
+    expect(component.formConfig().validationRules).toEqual([
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ]);
+  });
+
   it('should map submission payload to RegisterRequestDTO', () => {
     let emitted: RegisterRequestDTO | undefined;
     component.submitted.subscribe((value) => {
@@ -46,5 +57,51 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
       password: 'secret123',
       confirmPassword: 'secret123',
     });
+  });
+
+  it('should block submission when password confirmation does not match', async () => {
+    let emitted: RegisterRequestDTO | undefined;
+    component.submitted.subscribe((value) => {
+      emitted = value;
+    });
+
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const emailInput = nativeElement.querySelector(
+      'input#email',
+    ) as HTMLInputElement | null;
+    const passwordInput = nativeElement.querySelector(
+      'input#password',
+    ) as HTMLInputElement | null;
+    const confirmPasswordInput = nativeElement.querySelector(
+      'input#confirmPassword',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    expect(emailInput).toBeTruthy();
+    expect(passwordInput).toBeTruthy();
+    expect(confirmPasswordInput).toBeTruthy();
+    expect(submitButton).toBeTruthy();
+
+    emailInput!.value = 'jane@example.com';
+    emailInput!.dispatchEvent(new Event('input'));
+    passwordInput!.value = 'secret123';
+    passwordInput!.dispatchEvent(new Event('input'));
+    confirmPasswordInput!.value = 'secret124';
+    confirmPasswordInput!.dispatchEvent(new Event('input'));
+    confirmPasswordInput!.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton?.disabled).toBe(true);
+    expect(nativeElement.textContent).toContain('Passwords must match.');
+
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(emitted).toBeUndefined();
   });
 });

--- a/libs/auth/angular/ui/src/components/register-form/register-form.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.ts
@@ -51,6 +51,14 @@ export class AnarchitectsAuthUiRegisterForm {
         required: true,
       },
     ],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   });
 
   onSubmitted(input: SubmissionRequestDTO): void {

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
@@ -20,6 +20,17 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
     await fixture.whenStable();
   });
 
+  it('should configure confirmPassword to match password', () => {
+    expect(component.formConfig().validationRules).toEqual([
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ]);
+  });
+
   it('should map payload token and password fields', () => {
     let emitted: ResetPasswordRequestDTO | undefined;
     component.submitted.subscribe((value) => {

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
@@ -54,6 +54,14 @@ export class AnarchitectsAuthUiResetPasswordForm {
         ui: { label: 'Confirm Password' },
       },
     ],
+    validationRules: [
+      {
+        kind: 'matchFields',
+        sourceField: 'password',
+        targetField: 'confirmPassword',
+        message: 'Passwords must match.',
+      },
+    ],
   }));
 
   onSubmitted(input: SubmissionRequestDTO): void {


### PR DESCRIPTION
- add matchFields validationRules to register, reset-password, and change-password forms
- block auth form submission when confirmPassword does not match
- add auth UI coverage for validation rule wiring and rendered mismatch behavior