### PR TITLE
chore(governance): enforce human-in-the-loop workflow and sync docs

### DIFF
--- a/.agents/skills/project-board-sync/SKILL.md
+++ b/.agents/skills/project-board-sync/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: project-board-sync
+description: Keep GitHub Project 15 board status synchronized while implementing issues. USE WHEN user asks to start implementation, work an issue, create sub-issues, move issue status, or keep Board current during coding.
+---
+
+# Project Board Sync
+
+Use this skill during issue-driven implementation to keep the planning board aligned with actual execution.
+
+## Target Project
+
+- Project: https://github.com/orgs/anarchitects/projects/15
+- Owner: anarchitects
+- Number: 15
+- Working view: Board
+- Sprint field: Milestone
+- Status options: Backlog, Todo, In Progress, In Review, Blocked, Done
+
+## Required Workflow
+
+1. At implementation start:
+
+- Set active parent issue and active sub-issues to In Progress.
+
+2. During execution:
+
+- Set Blocked immediately when work cannot proceed.
+- Keep active and inactive issues separated.
+- Keep Milestone and Priority unchanged unless user asks to modify them.
+
+3. Review handoff:
+
+- Set issue to In Review when implementation is complete and review is requested or a PR is opened.
+
+4. Completion:
+
+- Set Done only after completion criteria are met.
+
+## Common Board Operations
+
+1. Read fields:
+
+- gh project field-list 15 --owner anarchitects --format json
+
+2. Read project items:
+
+- gh project item-list 15 --owner anarchitects --format json
+
+3. Edit one field value on one item:
+
+- gh project item-edit --id <item-id> --project-id <project-id> --field-id <field-id> --single-select-option-id <option-id>
+
+4. Add issue to project:
+
+- gh project item-add 15 --owner anarchitects --url https://github.com/anarchitects/anarchitecture-bricks-3tier/issues/<issue-number>
+
+## Status Mapping Guidance
+
+- Backlog: prioritized but not selected for active execution.
+- Todo: selected for active sprint but not started.
+- In Progress: currently being implemented.
+- In Review: implementation ready for review or PR stage.
+- Blocked: waiting for dependency, decision, or environment fix.
+- Done: accepted and complete.
+
+## Safety Rules
+
+- Use non-interactive gh commands.
+- Verify updates with a read-after-write query.
+- Avoid bulk overwrites without issue number filters.
+- Report changed issue numbers and resulting statuses in the final response.
+
+## Human In The Loop Rules
+
+- Treat board updates as AI-assisted planning operations under human supervision.
+- Human developers review code, perform commits, create PRs, and merge PRs.
+- AI coding agents may suggest commit messages, but commit execution remains human-owned.
+- When implementation changes may be breaking, explicitly call that out in updates and summaries.
+- When bug-fix impact suggests package deprecation on npm, explicitly call this out and require explicit human approval before any deprecation execution.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,6 +191,46 @@ State must be registered explicitly:
 - Keep example apps in sync with library integration contracts.
 - Keep APIs and documentation deterministic and reproducible.
 
+## Project Planning Workflow
+
+For issue-driven implementation work, agents must keep the GitHub planning board in sync with execution progress.
+
+- Project: https://github.com/orgs/anarchitects/projects/15
+- Working view: Board
+- Sprint field: Milestone
+- Status options: Backlog, Todo, In Progress, In Review, Blocked, Done
+
+### Status Transition Rules
+
+- Move issue to In Progress when active coding starts.
+- Move issue to Blocked when external dependencies prevent progress.
+- Move issue to In Review when implementation is ready for review or an implementation PR exists.
+- Move issue to Done when completion criteria are met.
+- Use Backlog or Todo for not-yet-started work based on planning intent.
+
+### Operational Rules
+
+- Include board updates as part of the implementation routine, not as a separate optional step.
+- Preserve existing Priority and Milestone unless user asks to change them.
+- For new sub-issues, add them to the project and assign Milestone according to the current sprint plan.
+
+## Human In The Loop Workflow
+
+AI coding agents operate in assistive mode and do not replace human code ownership.
+
+### Review And Delivery
+
+- Human developers review all AI-proposed code changes.
+- Human developers perform git commit operations.
+- Human developers create and merge pull requests.
+- AI coding agents may suggest commit messages, but must not treat suggestions as committed history.
+
+### Breaking Change And Deprecation Handling
+
+- AI coding agents must explicitly state when a change introduces potential breaking behavior.
+- AI coding agents must explicitly state when a bug fix may justify npm package deprecation of previously published versions.
+- AI coding agents may prepare deprecation instructions, but execution is allowed only after explicit human approval.
+
 ## Don't
 
 - Reintroduce `contracts/openapi.yaml` as source-of-truth.

--- a/.github/skills/project-board-sync/SKILL.md
+++ b/.github/skills/project-board-sync/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: project-board-sync
+description: Keep GitHub Project 15 board status synchronized while implementing issues. USE WHEN user asks to start implementation, work an issue, create sub-issues, move issue status, or keep Board current during coding.
+---
+
+# Project Board Sync
+
+Use this skill during issue-driven implementation to keep the planning board aligned with actual execution.
+
+## Target Project
+
+- Project: https://github.com/orgs/anarchitects/projects/15
+- Owner: anarchitects
+- Number: 15
+- Working view: Board
+- Sprint field: Milestone
+- Status options: Backlog, Todo, In Progress, In Review, Blocked, Done
+
+## Required Workflow
+
+1. At implementation start:
+
+- Set active parent issue and active sub-issues to In Progress.
+
+2. During execution:
+
+- Set Blocked immediately when work cannot proceed.
+- Keep active and inactive issues separated.
+- Keep Milestone and Priority unchanged unless user asks to modify them.
+
+3. Review handoff:
+
+- Set issue to In Review when implementation is complete and review is requested or a PR is opened.
+
+4. Completion:
+
+- Set Done only after completion criteria are met.
+
+## Common Board Operations
+
+1. Read fields:
+
+- gh project field-list 15 --owner anarchitects --format json
+
+2. Read project items:
+
+- gh project item-list 15 --owner anarchitects --format json
+
+3. Edit one field value on one item:
+
+- gh project item-edit --id <item-id> --project-id <project-id> --field-id <field-id> --single-select-option-id <option-id>
+
+4. Add issue to project:
+
+- gh project item-add 15 --owner anarchitects --url https://github.com/anarchitects/anarchitecture-bricks-3tier/issues/<issue-number>
+
+## Status Mapping Guidance
+
+- Backlog: prioritized but not selected for active execution.
+- Todo: selected for active sprint but not started.
+- In Progress: currently being implemented.
+- In Review: implementation ready for review or PR stage.
+- Blocked: waiting for dependency, decision, or environment fix.
+- Done: accepted and complete.
+
+## Safety Rules
+
+- Use non-interactive gh commands.
+- Verify updates with a read-after-write query.
+- Avoid bulk overwrites without issue number filters.
+- Report changed issue numbers and resulting statuses in the final response.
+
+## Human In The Loop Rules
+
+- Treat board updates as AI-assisted planning operations under human supervision.
+- Human developers review code, perform commits, create PRs, and merge PRs.
+- AI coding agents may suggest commit messages, but commit execution remains human-owned.
+- When implementation changes may be breaking, explicitly call that out in updates and summaries.
+- When bug-fix impact suggests package deprecation on npm, explicitly call this out and require explicit human approval before any deprecation execution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,54 @@ You are an engineering assistant for an Nx monorepo containing reusable librarie
 - Passing lint/build/test for affected scope.
 - Consistent architecture boundaries and naming.
 
+## Project Planning And Board Sync
+
+When executing work tied to GitHub issues in this repository, keep the planning board synchronized as part of the implementation workflow.
+
+- Planning project: https://github.com/orgs/anarchitects/projects/15
+- Working view: Board
+- Sprint field: Milestone
+- Status field values: Backlog, Todo, In Progress, In Review, Blocked, Done
+
+### Required Behavior During Issue Work
+
+- Before coding starts on an issue, set the issue Status to In Progress.
+- If work is intentionally queued or deferred, set Status to Backlog.
+- If work is ready and selected for active execution but not started, set Status to Todo.
+- If blocked by dependency, environment, or decision gate, set Status to Blocked.
+- When a PR is opened for the issue, set Status to In Review.
+- When work is fully completed and validated, set Status to Done.
+
+### Scope Rules
+
+- Apply board status updates to parent issues and sub-issues involved in the current implementation.
+- Keep Priority and Milestone values intact unless user explicitly asks to change them.
+- When creating new implementation sub-issues, assign Milestone based on sprint plan and add to project 15.
+- Prefer non-interactive gh commands and confirm updates by querying project items after bulk changes.
+
+## Human In The Loop Governance
+
+For all implementation work, keep humans as the control point for code acceptance and release actions.
+
+### Ownership Rules
+
+- AI coding agents may analyze, edit files, run validation, and suggest commit messages.
+- Human developers review all code changes.
+- Human developers perform git commit, pull request creation, and pull request merge.
+- AI coding agents must never finalize commits or merge PRs as a replacement for human review.
+
+### Breaking Change And Deprecation Disclosure
+
+- AI coding agents must explicitly call out potential breaking changes in every implementation summary when applicable.
+- AI coding agents must explicitly call out when a bug fix may warrant npm package deprecation of existing published versions.
+- AI coding agents may propose and prepare deprecation actions, but execution requires explicit human approval.
+- Until human approval is provided, deprecation operations must remain proposed-only.
+
+### Commit Guidance
+
+- AI coding agents should always suggest one or more clear commit message options.
+- Human developers execute the final commit command.
+
 ## Release Workflow Rules
 
 - Release ownership is CI-based via GitHub Actions, not local developer machines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,17 @@ nx run release-tools:validate-non-bumping-commits
 - CI also enforces docs completeness via `nx run docs-hub:validate-content` (required headings for publishable package READMEs and Angular/Nest markdown guides).
 - Squash-merge subject for docs-surface PRs must use `docs:`, `chore:`, `ci:`, or `style:`.
 
+## Human-In-The-Loop Shortlist
+
+See the top-level policy summary in [README.md](README.md#human-in-the-loop-shortlist).
+
+- Humans review all AI-proposed code changes.
+- Humans own `git commit`, pull request creation, and pull request merge.
+- AI agents must explicitly call out potential breaking changes.
+- AI agents must explicitly call out when a bug fix may justify npm package deprecation.
+- Deprecation actions are proposed-only until explicit human approval is provided.
+- AI agents may suggest commit message options; humans run the final commit command.
+
 ## Release Workflow (Domain Groups)
 
 - Trigger the **Release (Manual)** GitHub Actions workflow from `main`.

--- a/README.md
+++ b/README.md
@@ -106,25 +106,25 @@ nx run forms-angular-example:contract-test
 
 ## Key Nx Targets
 
-| Command                                      | Description                                           |
-| -------------------------------------------- | ----------------------------------------------------- |
-| `nx run api-specs:generate`                  | Generate OpenAPI JSON/YAML from Nest controllers      |
-| `nx run api-specs:lint`                      | Lint generated OpenAPI                                |
-| `nx run api-specs:diff`                      | Compare generated OpenAPI against `origin/main`       |
-| `nx run api-specs:mock`                      | Run Prism mock server from generated OpenAPI          |
-| `nx run api-specs:verify`                    | Validate required endpoints + snapshot stability      |
-| `nx run angular-docs:generate`               | Generate and merge Compodoc docs                      |
-| `nx run docs-hub:validate-content`           | Enforce required docs sections for guides and READMEs |
-| `nx run storybook-angular:build-storybook`   | Build Storybook with technical docs metadata          |
-| `nx run docs-hub:build`                      | Build static docs hub pages                           |
-| `nx run docs-hub:verify`                     | Validate docs hub outputs and required links          |
-| `nx run release-tools:validate-non-bumping-commits` | Enforce non-bumping commit types for docs-surface PRs |
+| Command                                                    | Description                                           |
+| ---------------------------------------------------------- | ----------------------------------------------------- |
+| `nx run api-specs:generate`                                | Generate OpenAPI JSON/YAML from Nest controllers      |
+| `nx run api-specs:lint`                                    | Lint generated OpenAPI                                |
+| `nx run api-specs:diff`                                    | Compare generated OpenAPI against `origin/main`       |
+| `nx run api-specs:mock`                                    | Run Prism mock server from generated OpenAPI          |
+| `nx run api-specs:verify`                                  | Validate required endpoints + snapshot stability      |
+| `nx run angular-docs:generate`                             | Generate and merge Compodoc docs                      |
+| `nx run docs-hub:validate-content`                         | Enforce required docs sections for guides and READMEs |
+| `nx run storybook-angular:build-storybook`                 | Build Storybook with technical docs metadata          |
+| `nx run docs-hub:build`                                    | Build static docs hub pages                           |
+| `nx run docs-hub:verify`                                   | Validate docs hub outputs and required links          |
+| `nx run release-tools:validate-non-bumping-commits`        | Enforce non-bumping commit types for docs-surface PRs |
 | `nx run release-tools:domain-release -- --domain=forms -d` | Dry-run the supported domain release workflow         |
-| `nx run auth-nest-example:contract-test`     | Validate auth Nest runtime responses against OpenAPI  |
-| `nx run auth-angular-example:contract-test`  | Validate auth Angular data-access against Prism mock  |
-| `nx run forms-nest-example:contract-test`    | Validate Nest runtime responses against OpenAPI       |
-| `nx run forms-angular-example:contract-test` | Validate Angular data-access calls against Prism mock |
-| `nx affected -t lint test build`             | Standard affected checks                              |
+| `nx run auth-nest-example:contract-test`                   | Validate auth Nest runtime responses against OpenAPI  |
+| `nx run auth-angular-example:contract-test`                | Validate auth Angular data-access against Prism mock  |
+| `nx run forms-nest-example:contract-test`                  | Validate Nest runtime responses against OpenAPI       |
+| `nx run forms-angular-example:contract-test`               | Validate Angular data-access calls against Prism mock |
+| `nx affected -t lint test build`                           | Standard affected checks                              |
 
 ## Release By Domain
 
@@ -174,6 +174,17 @@ If local dry-runs are needed, use the repo runner, for example `yarn nx run rele
 - Do not use `!` or `BREAKING CHANGE` markers in docs-surface commits.
 - CI enforces this via `nx run release-tools:validate-non-bumping-commits`.
 - For squash merges of docs-surface PRs, use a non-bumping squash subject (`docs:`, `chore:`, `ci:`, or `style:`).
+
+## Human-In-The-Loop Shortlist
+
+See the contributor workflow context in [CONTRIBUTING.md](CONTRIBUTING.md#human-in-the-loop-shortlist).
+
+- Humans review all AI-proposed code changes.
+- Humans own `git commit`, pull request creation, and pull request merge.
+- AI agents must explicitly call out potential breaking changes.
+- AI agents must explicitly call out when a bug fix may justify npm package deprecation.
+- Deprecation actions are proposed-only until explicit human approval is provided.
+- AI agents may suggest commit message options; humans run the final commit command.
 
 ## License
 


### PR DESCRIPTION
- add project-board-sync skill definitions for board/status workflow
- codify human ownership of review, commit, PR, and merge actions
- require explicit AI callouts for breaking changes and deprecation impact
- add and cross-link Human-In-The-Loop shortlist in contributor docs