### PR TITLE
fix(auth): fail closed on malformed frontend and backend auth rules

### DIFF
--- a/libs/auth/angular/data-access/src/auth-api.spec.ts
+++ b/libs/auth/angular/data-access/src/auth-api.spec.ts
@@ -4,6 +4,7 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { AuthApi } from './auth-api';
 import { SUPPRESS_AUTH_FAILURE_REDIRECT } from './interceptors/auth-error.interceptor';
 
@@ -188,6 +189,18 @@ describe('AuthApi', () => {
         user: { id: 'user-123', email: 'user@example.com' },
         rbac: [{ action: 'read', subject: 'Project' }],
       });
+    });
+
+    it('should reject malformed rbac payloads at the API boundary', async () => {
+      const responsePromise = firstValueFrom(service.getLoggedInUserInfo());
+      const req = httpController.expectOne('/api/auth/me');
+
+      req.flush({
+        user: { id: 'user-123', email: 'user@example.com' },
+        rbac: [{ action: 'read', subject: '' }],
+      });
+
+      await expect(responsePromise).rejects.toThrow(/Invalid rbac/);
     });
   });
 });

--- a/libs/auth/angular/data-access/src/auth-api.ts
+++ b/libs/auth/angular/data-access/src/auth-api.ts
@@ -12,10 +12,12 @@ import {
   ResetPasswordRequestDTO,
   UpdateEmailRequestDTO,
   VerifyEmailRequestDTO,
+  parsePolicyRuleArrayDTO,
 } from '@anarchitects/auth-ts/dtos';
 import { PolicyRule, User } from '@anarchitects/auth-ts/models';
 import { HttpClient, HttpContext } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { map } from 'rxjs';
 import { SUPPRESS_AUTH_FAILURE_REDIRECT } from './interceptors/auth-error.interceptor';
 
 export type AuthApiRequestOptions = {
@@ -101,9 +103,16 @@ export class AuthApi {
       ? new HttpContext().set(SUPPRESS_AUTH_FAILURE_REDIRECT, true)
       : undefined;
 
-    return this.http.get<{ user: User; rbac: PolicyRule[] }>(
-      `${this.resourceUrl}/me`,
-      context ? { context } : undefined,
-    );
+    return this.http
+      .get<{ user: User; rbac: unknown }>(
+        `${this.resourceUrl}/me`,
+        context ? { context } : undefined,
+      )
+      .pipe(
+        map(({ user, rbac }) => ({
+          user,
+          rbac: parsePolicyRuleArrayDTO(rbac, 'rbac') as PolicyRule[],
+        })),
+      );
   }
 }

--- a/libs/auth/angular/data-access/src/interceptors/auth-error.interceptor.spec.ts
+++ b/libs/auth/angular/data-access/src/interceptors/auth-error.interceptor.spec.ts
@@ -10,16 +10,14 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
-import { jwtDecode } from 'jwt-decode';
 import { authBearerTokenInterceptor } from './bearer-token.interceptor';
 import {
   authErrorInterceptor,
   SUPPRESS_AUTH_FAILURE_REDIRECT,
 } from './auth-error.interceptor';
 
-vi.mock('jwt-decode', () => ({
-  jwtDecode: vi.fn(),
-}));
+const decodableAccessToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.signature';
 
 describe('authErrorInterceptor', () => {
   let http: HttpClient;
@@ -51,9 +49,8 @@ describe('authErrorInterceptor', () => {
   });
 
   it('should refresh tokens and retry request on 403', () => {
-    localStorage.setItem('accessToken', 'expired-access-token');
+    localStorage.setItem('accessToken', decodableAccessToken);
     localStorage.setItem('refreshToken', 'refresh-token');
-    vi.mocked(jwtDecode).mockReturnValue({ sub: 'user-123' });
 
     const responseSpy = vi.fn();
 
@@ -61,7 +58,7 @@ describe('authErrorInterceptor', () => {
 
     const initialReq = httpController.expectOne('/api/protected');
     expect(initialReq.request.headers.get('Authorization')).toBe(
-      'Bearer expired-access-token'
+      `Bearer ${decodableAccessToken}`
     );
     initialReq.flush(
       { message: 'forbidden' },
@@ -91,8 +88,7 @@ describe('authErrorInterceptor', () => {
   });
 
   it('should redirect to login when refresh token is missing', () => {
-    localStorage.setItem('accessToken', 'expired-access-token');
-    vi.mocked(jwtDecode).mockReturnValue({ sub: 'user-123' });
+    localStorage.setItem('accessToken', decodableAccessToken);
 
     const errorSpy = vi.fn();
 
@@ -114,9 +110,8 @@ describe('authErrorInterceptor', () => {
   });
 
   it('should redirect to login when refresh request fails', () => {
-    localStorage.setItem('accessToken', 'expired-access-token');
+    localStorage.setItem('accessToken', decodableAccessToken);
     localStorage.setItem('refreshToken', 'refresh-token');
-    vi.mocked(jwtDecode).mockReturnValue({ sub: 'user-123' });
 
     const errorSpy = vi.fn();
 
@@ -143,9 +138,8 @@ describe('authErrorInterceptor', () => {
   });
 
   it('should not attempt refresh for public login endpoint failures', () => {
-    localStorage.setItem('accessToken', 'expired-access-token');
+    localStorage.setItem('accessToken', decodableAccessToken);
     localStorage.setItem('refreshToken', 'refresh-token');
-    vi.mocked(jwtDecode).mockReturnValue({ sub: 'user-123' });
 
     const errorSpy = vi.fn();
 
@@ -167,9 +161,8 @@ describe('authErrorInterceptor', () => {
   });
 
   it('should suppress redirect when the request opts out during startup restore', () => {
-    localStorage.setItem('accessToken', 'expired-access-token');
+    localStorage.setItem('accessToken', decodableAccessToken);
     localStorage.setItem('refreshToken', 'refresh-token');
-    vi.mocked(jwtDecode).mockReturnValue({ sub: 'user-123' });
 
     const errorSpy = vi.fn();
 

--- a/libs/auth/angular/feature/src/guards/policy.guard.spec.ts
+++ b/libs/auth/angular/feature/src/guards/policy.guard.spec.ts
@@ -129,4 +129,19 @@ describe('policyGuard', () => {
 
     await expect(canMatchPromise).resolves.toBe(true);
   });
+
+  it('should fail closed for malformed rule arrays', async () => {
+    setup({
+      rbac: [null] as unknown as PolicyRule[],
+    });
+
+    const canMatch = await firstValueFrom(
+      executeGuard(
+        { data: { action: 'read', subject: 'Document' } } as never,
+        [],
+      ) as Observable<boolean>,
+    );
+
+    expect(canMatch).toBe(false);
+  });
 });

--- a/libs/auth/angular/feature/src/guards/resource-policy.guard.spec.ts
+++ b/libs/auth/angular/feature/src/guards/resource-policy.guard.spec.ts
@@ -153,4 +153,40 @@ describe('resourcePolicyGuard', () => {
 
     await expect(resultPromise).resolves.toBe(true);
   });
+
+  it('redirects when the resource payload is missing or malformed', async () => {
+    const { router } = setup({
+      rbac: [{ action: 'read', subject: 'Post' }],
+    });
+
+    const missingResult = await firstValueFrom(
+      executeGuard(
+        {
+          data: {
+            action: 'read',
+            resourceKey: 'post',
+            subject: 'Post',
+          },
+        } as never,
+        { url: '/posts/post-1/edit' } as never,
+      ) as Observable<boolean | UrlTree>,
+    );
+
+    const invalidResult = await firstValueFrom(
+      executeGuard(
+        {
+          data: {
+            action: 'read',
+            resourceKey: 'post',
+            subject: 'Post',
+            post: 'not-an-object',
+          },
+        } as never,
+        { url: '/posts/post-1/edit' } as never,
+      ) as Observable<boolean | UrlTree>,
+    );
+
+    expect(router.serializeUrl(missingResult as UrlTree)).toBe('/posts/post-1');
+    expect(router.serializeUrl(invalidResult as UrlTree)).toBe('/posts/post-1');
+  });
 });

--- a/libs/auth/angular/state/src/auth.store.spec.ts
+++ b/libs/auth/angular/state/src/auth.store.spec.ts
@@ -192,6 +192,26 @@ describe('AuthStore', () => {
     expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/login');
   });
 
+  it('clears tokens and session when login hydration rejects malformed rbac', async () => {
+    const { store } = setup({
+      authApiOverrides: {
+        getLoggedInUserInfo: vi.fn(() =>
+          throwError(() => new Error('Invalid rbac.')),
+        ),
+      },
+    });
+
+    store.login({ credential: 'testuser', password: 'password' });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+    expect(store.isLoggedIn()).toBe(false);
+    expect(store.rbac()).toEqual([]);
+    expect(store.ability()).toBeUndefined();
+    expect(store.error()).toBe('Invalid rbac.');
+  });
+
   it('hydrates raw rbac and ability on login', async () => {
     const { store } = setup();
 
@@ -243,6 +263,32 @@ describe('AuthStore', () => {
     expect(store.isLoggedIn()).toBe(true);
     expect(store.rbac()).toEqual(hydratedSession.rbac);
     expect(store.ability()?.can('update', 'Post')).toBe(true);
+  });
+
+  it('clears tokens and session when refresh hydration rejects malformed rbac', async () => {
+    localStorage.setItem('accessToken', validAccessToken);
+    localStorage.setItem('refreshToken', validRefreshToken);
+
+    const { store } = setup({
+      authApiOverrides: {
+        getLoggedInUserInfo: vi.fn(() =>
+          throwError(() => new Error('Invalid rbac.')),
+        ),
+      },
+    });
+
+    store.refreshTokens({
+      userId: 'user-id',
+      dto: { refreshToken: validRefreshToken },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+    expect(store.isLoggedIn()).toBe(false);
+    expect(store.rbac()).toEqual([]);
+    expect(store.ability()).toBeUndefined();
+    expect(store.error()).toBe('Invalid rbac.');
   });
 
   it('toggles restoring only around bootstrap restore', async () => {

--- a/libs/auth/angular/state/src/auth.store.ts
+++ b/libs/auth/angular/state/src/auth.store.ts
@@ -38,7 +38,7 @@ import {
   withEntities,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { EMPTY, pipe, switchMap, tap } from 'rxjs';
+import { catchError, EMPTY, pipe, switchMap, tap, throwError } from 'rxjs';
 import { AUTH_STATE_OPTIONS } from './auth-state.options';
 
 type AuthState = {
@@ -127,6 +127,18 @@ const redirectToLogin = (router: Router | null): void => {
   if (typeof window !== 'undefined') {
     window.location.assign(LOGIN_REDIRECT_PATH);
   }
+};
+
+const failClosedHydration = (
+  store: object,
+  error: unknown,
+  state: Partial<AuthState> = {},
+) => {
+  clearStoredTokens();
+  clearAuthenticatedSession(store, {
+    error: toErrorMessage(error),
+    ...state,
+  });
 };
 
 export const AuthStore = signalStore(
@@ -277,7 +289,12 @@ export const AuthStore = signalStore(
                 return EMPTY;
               }
 
-              return store._authApi.getLoggedInUserInfo();
+              return store._authApi.getLoggedInUserInfo().pipe(
+                catchError((error: unknown) => {
+                  failClosedHydration(store, error, { initialized: true });
+                  return throwError(() => error);
+                }),
+              );
             }),
             tapResponse({
               next: ({ user, rbac }) => {
@@ -291,7 +308,10 @@ export const AuthStore = signalStore(
                 patchState(store, { initialized: true });
               },
               error: (error: unknown) => {
-                patchState(store, { error: toErrorMessage(error) });
+                patchState(store, {
+                  error: toErrorMessage(error),
+                  initialized: true,
+                });
               },
               finalize: () => {
                 patchState(store, { loading: false });
@@ -439,7 +459,12 @@ export const AuthStore = signalStore(
                 return EMPTY;
               }
 
-              return store._authApi.getLoggedInUserInfo();
+              return store._authApi.getLoggedInUserInfo().pipe(
+                catchError((error: unknown) => {
+                  failClosedHydration(store, error, { initialized: true });
+                  return throwError(() => error);
+                }),
+              );
             }),
             tapResponse({
               next: ({ user, rbac }) => {
@@ -453,7 +478,10 @@ export const AuthStore = signalStore(
                 patchState(store, { initialized: true });
               },
               error: (error: unknown) => {
-                patchState(store, { error: toErrorMessage(error) });
+                patchState(store, {
+                  error: toErrorMessage(error),
+                  initialized: true,
+                });
               },
               finalize: () => {
                 patchState(store, { loading: false });

--- a/libs/auth/angular/util/src/ability.factory.spec.ts
+++ b/libs/auth/angular/util/src/ability.factory.spec.ts
@@ -116,4 +116,32 @@ describe('Ability', () => {
       ability.can('update', subject('Post', { id: 'post-2', archived: true })),
     ).toBe(false);
   });
+
+  it('fails closed when malformed rules are provided', () => {
+    const ability = createAppAbility([null] as unknown as PolicyRule[]);
+
+    expect(ability.can('read', 'Post')).toBe(false);
+  });
+
+  it('returns false for malformed concrete resource inputs', () => {
+    const ability = createAppAbility([{ action: 'read', subject: 'Post' }]);
+
+    expect(
+      canAccessResource(
+        ability,
+        'read',
+        'Post',
+        null as unknown as Record<string, unknown>,
+      ),
+    ).toBe(false);
+    expect(
+      canAccessResourceField(
+        ability,
+        'read',
+        'Post',
+        'title',
+        null as unknown as Record<string, unknown>,
+      ),
+    ).toBe(false);
+  });
 });

--- a/libs/auth/angular/util/src/ability.factory.ts
+++ b/libs/auth/angular/util/src/ability.factory.ts
@@ -1,3 +1,4 @@
+import { parsePolicyRuleArrayDTO } from '@anarchitects/auth-ts/dtos';
 import { Action, PolicyRule, Subject } from '@anarchitects/auth-ts/models';
 import { createMongoAbility, MongoAbility, subject } from '@casl/ability';
 
@@ -7,8 +8,19 @@ type AbilityResource = Record<string, unknown>;
 
 export type AppAbility = MongoAbility<[Action, AbilitySubject]>;
 
+const toSafePolicyRules = (rules: PolicyRule[]): PolicyRule[] => {
+  try {
+    return parsePolicyRuleArrayDTO(rules, 'rbac');
+  } catch {
+    return [];
+  }
+};
+
+const isAbilityResource = (value: unknown): value is AbilityResource =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
 export const createAppAbility = (rules: PolicyRule[]): AppAbility =>
-  createMongoAbility(rules) as AppAbility;
+  createMongoAbility(toSafePolicyRules(rules)) as AppAbility;
 
 export const asAppAbilitySubject = <TResource extends AbilityResource>(
   subjectName: Subject,
@@ -22,11 +34,15 @@ export const canAccessResource = <TResource extends AbilityResource>(
   subjectName: Subject,
   resource: TResource,
 ): boolean => {
-  if (!ability) {
+  if (!ability || !isAbilityResource(resource)) {
     return false;
   }
 
-  return ability.can(action, asAppAbilitySubject(subjectName, resource));
+  try {
+    return ability.can(action, asAppAbilitySubject(subjectName, resource));
+  } catch {
+    return false;
+  }
 };
 
 export const canAccessResourceField = <TResource extends AbilityResource>(
@@ -36,13 +52,17 @@ export const canAccessResourceField = <TResource extends AbilityResource>(
   field: string,
   resource: TResource,
 ): boolean => {
-  if (!ability) {
+  if (!ability || !isAbilityResource(resource)) {
     return false;
   }
 
-  return ability.can(
-    action,
-    asAppAbilitySubject(subjectName, resource),
-    field,
-  );
+  try {
+    return ability.can(
+      action,
+      asAppAbilitySubject(subjectName, resource),
+      field,
+    );
+  } catch {
+    return false;
+  }
 };

--- a/libs/auth/nest/src/application/services/jwt-auth.service.spec.ts
+++ b/libs/auth/nest/src/application/services/jwt-auth.service.spec.ts
@@ -8,6 +8,75 @@ import { JwtService } from '@nestjs/jwt';
 describe('JwtAuthService', () => {
   let service: JwtAuthService;
 
+  const malformedPermissions = [
+    {
+      description: 'empty action',
+      permission: {
+        action: '',
+        subject: 'Project',
+        conditions: null,
+        fields: null,
+        inverted: false,
+        reason: null,
+      },
+    },
+    {
+      description: 'missing subject',
+      permission: {
+        action: 'read',
+        subject: undefined,
+        conditions: null,
+        fields: null,
+        inverted: false,
+        reason: null,
+      },
+    },
+    {
+      description: 'invalid conditions',
+      permission: {
+        action: 'read',
+        subject: 'Project',
+        conditions: [],
+        fields: null,
+        inverted: false,
+        reason: null,
+      },
+    },
+    {
+      description: 'invalid fields',
+      permission: {
+        action: 'read',
+        subject: 'Project',
+        conditions: null,
+        fields: 'name',
+        inverted: false,
+        reason: null,
+      },
+    },
+    {
+      description: 'invalid inverted flag',
+      permission: {
+        action: 'read',
+        subject: 'Project',
+        conditions: null,
+        fields: null,
+        inverted: 'true',
+        reason: null,
+      },
+    },
+    {
+      description: 'invalid reason',
+      permission: {
+        action: 'read',
+        subject: 'Project',
+        conditions: null,
+        fields: null,
+        inverted: false,
+        reason: 123,
+      },
+    },
+  ];
+
   let mockHashService: {
     hash: jest.Mock;
     compare: jest.Mock;
@@ -463,29 +532,23 @@ describe('JwtAuthService', () => {
       });
     });
 
-    it('should fail closed on malformed persisted policy rules', async () => {
-      mockAuthUserRepository.findOne.mockResolvedValueOnce({
-        id: 'user-id',
-        email: 'user@example.com',
-        roles: [
-          {
-            permissions: [
-              {
-                action: '',
-                subject: 'Project',
-                conditions: null,
-                fields: null,
-                inverted: false,
-                reason: null,
-              },
-            ],
-          },
-        ],
-      });
+    it.each(malformedPermissions)(
+      'should fail closed on malformed persisted policy rules: $description',
+      async ({ permission }) => {
+        mockAuthUserRepository.findOne.mockResolvedValueOnce({
+          id: 'user-id',
+          email: 'user@example.com',
+          roles: [
+            {
+              permissions: [permission],
+            },
+          ],
+        });
 
-      await expect(service.getLoggedInUserInfo('user-id')).rejects.toThrow(
-        InternalServerErrorException,
-      );
-    });
+        await expect(service.getLoggedInUserInfo('user-id')).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      },
+    );
   });
 });

--- a/libs/auth/nest/src/application/services/policies.service.spec.ts
+++ b/libs/auth/nest/src/application/services/policies.service.spec.ts
@@ -53,6 +53,38 @@ describe('PoliciesService', () => {
     },
   ];
 
+  const malformedPermissions: Array<{
+    description: string;
+    permission: Partial<Permission>;
+  }> = [
+    {
+      description: 'empty action',
+      permission: { action: '' },
+    },
+    {
+      description: 'missing subject',
+      permission: { subject: undefined },
+    },
+    {
+      description: 'non-object conditions',
+      permission: {
+        conditions: [] as unknown as Record<string, unknown>,
+      },
+    },
+    {
+      description: 'invalid fields payload',
+      permission: { fields: 'title' as unknown as string[] },
+    },
+    {
+      description: 'non-boolean inverted',
+      permission: { inverted: 'true' as unknown as boolean },
+    },
+    {
+      description: 'non-string reason',
+      permission: { reason: 123 as unknown as string },
+    },
+  ];
+
   const mockAuthUserRepository = {
     findOne: jest.fn().mockResolvedValue(mockUser),
   };
@@ -82,26 +114,29 @@ describe('PoliciesService', () => {
       expect(permissions).toEqual(expectedPolicyRules);
     });
 
-    it('should fail closed on malformed persisted policy rules', async () => {
-      mockAuthUserRepository.findOne.mockResolvedValueOnce({
-        ...mockUser,
-        roles: [
-          {
-            ...mockRole,
-            permissions: [
-              {
-                ...mockPermission,
-                action: '',
-              },
-            ],
-          },
-        ],
-      });
+    it.each(malformedPermissions)(
+      'should fail closed on malformed persisted policy rules: $description',
+      async ({ permission }) => {
+        mockAuthUserRepository.findOne.mockResolvedValueOnce({
+          ...mockUser,
+          roles: [
+            {
+              ...mockRole,
+              permissions: [
+                {
+                  ...mockPermission,
+                  ...permission,
+                },
+              ],
+            },
+          ],
+        });
 
-      await expect(service.rulesForUser(mockUser)).rejects.toThrow(
-        InternalServerErrorException,
-      );
-    });
+        await expect(service.rulesForUser(mockUser)).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      },
+    );
   });
 
   describe('buildAbilityForUser', () => {

--- a/libs/auth/nest/src/presentation/guards/policies.guard.spec.ts
+++ b/libs/auth/nest/src/presentation/guards/policies.guard.spec.ts
@@ -141,4 +141,17 @@ describe('PoliciesGuard', () => {
       guard.canActivate(createExecutionContext({ id: 'user-1' })),
     ).rejects.toThrow(ForbiddenException);
   });
+
+  it('bubbles malformed persisted policy failures instead of allowing access', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([
+      { action: 'update', subject: 'Post' },
+    ]);
+    mockPoliciesService.rulesForUser.mockRejectedValue(
+      new Error('Malformed persisted policy rule payload'),
+    );
+
+    await expect(
+      guard.canActivate(createExecutionContext({ id: 'user-1' })),
+    ).rejects.toThrow('Malformed persisted policy rule payload');
+  });
 });

--- a/libs/auth/nest/src/presentation/guards/resource-authorization.guard.spec.ts
+++ b/libs/auth/nest/src/presentation/guards/resource-authorization.guard.spec.ts
@@ -251,4 +251,22 @@ describe('ResourceAuthorizationGuard', () => {
       ),
     ).rejects.toThrow(ForbiddenException);
   });
+
+  it('fails when ability construction rejects malformed persisted rules', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([
+      { action: 'read', subject: 'Post', idParam: 'postId' },
+    ]);
+    mockPoliciesService.buildAbilityForUser.mockRejectedValue(
+      new Error('Malformed persisted policy rule payload'),
+    );
+
+    await expect(
+      guard.canActivate(
+        createExecutionContext({
+          user: { id: 'user-1' },
+          params: { postId: 'post-1' },
+        }),
+      ),
+    ).rejects.toThrow('Malformed persisted policy rule payload');
+  });
 });

--- a/libs/auth/ts/src/models/route-policy.spec.ts
+++ b/libs/auth/ts/src/models/route-policy.spec.ts
@@ -83,4 +83,29 @@ describe('route policy matcher', () => {
       ]),
     ).toBe(true);
   });
+
+  it('fails closed for malformed rule entries', () => {
+    expect(
+      canAttemptRoutePolicy(routePolicy, [null] as unknown as never[]),
+    ).toBe(false);
+    expect(
+      canAttemptRoutePolicy(routePolicy, [
+        { action: 'update', subject: '' },
+      ] as unknown as never[]),
+    ).toBe(false);
+    expect(
+      canAttemptRoutePolicy(routePolicy, [
+        { action: 'update', subject: 'Post', extra: true },
+      ] as unknown as never[]),
+    ).toBe(false);
+  });
+
+  it('fails closed for malformed route policy metadata', () => {
+    expect(
+      canAttemptRoutePolicy(
+        { action: '', subject: 'Post' } as unknown as never,
+        [{ action: 'update', subject: 'Post' }],
+      ),
+    ).toBe(false);
+  });
 });

--- a/libs/auth/ts/src/models/route-policy.ts
+++ b/libs/auth/ts/src/models/route-policy.ts
@@ -1,6 +1,30 @@
+import { parsePolicyRuleDTO } from '../dtos';
 import { PolicyRule } from './auth.types';
 
 export type RoutePolicy = Pick<PolicyRule, 'action' | 'subject'>;
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0;
+
+const isRoutePolicy = (value: unknown): value is RoutePolicy =>
+  !!value &&
+  typeof value === 'object' &&
+  isNonEmptyString((value as RoutePolicy).action) &&
+  isNonEmptyString((value as RoutePolicy).subject);
+
+const parseRoutePolicyRules = (value: unknown): PolicyRule[] | null => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  try {
+    return value.map((policyRule, index) =>
+      parsePolicyRuleDTO(policyRule, `policyRules[${index}]`),
+    );
+  } catch {
+    return null;
+  }
+};
 
 const matchesRoutePolicy = (
   routePolicy: RoutePolicy,
@@ -17,7 +41,16 @@ export const canAttemptRoutePolicy = (
   routePolicy: RoutePolicy,
   policyRules: PolicyRule[],
 ): boolean => {
-  const matchingRules = policyRules.filter((policyRule) =>
+  if (!isRoutePolicy(routePolicy)) {
+    return false;
+  }
+
+  const parsedPolicyRules = parseRoutePolicyRules(policyRules);
+  if (!parsedPolicyRules) {
+    return false;
+  }
+
+  const matchingRules = parsedPolicyRules.filter((policyRule) =>
     matchesRoutePolicy(routePolicy, policyRule),
   );
 


### PR DESCRIPTION
Harden auth trust boundaries across auth-ts, auth-nest, and auth-angular so malformed authorization payloads deny access or reset session state instead of being partially trusted.

- make shared route-policy matching fail closed for malformed rule arrays and invalid route metadata
- validate /auth/me rbac payloads at the auth-angular API boundary before store hydration
- clear tokens and reset auth state when login, refresh, or restore hydration receives malformed rbac
- harden frontend ability and resource helpers to return false for malformed rule or resource inputs
- expand backend negative-path coverage for malformed persisted permission payloads in policies and jwt auth services
- add guard-level tests to prove malformed persisted authorization data does not leak through route or resource authorization
- add frontend guard, API, store, and ability tests for malformed-input and trust-boundary behavior
- stabilize auth error interceptor tests with real decodable JWT-shaped tokens

Closes #114 Refs #108