### PR TITLE
docs(auth): clarify CASL integration boundaries and policy contracts

### DIFF
--- a/docs/guides/angular.md
+++ b/docs/guides/angular.md
@@ -73,6 +73,17 @@ Angular consumers (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`) 
 - Keep `feature` as composition/orchestration and `ui` as presentational/token-driven.
 - Sync backend schema changes by regenerating OpenAPI and updating Angular adapters before merge.
 
+## Auth CASL Guidance
+
+For `@anarchitects/auth-angular`, keep the authorization split explicit:
+
+- `@anarchitects/auth-ts` owns the serialized auth rule shape
+- `policyGuard` is a coarse route-attempt check over `{ action, subject }`
+- `resourcePolicyGuard` is for resolved-resource routes
+- `canAccessResource(...)` and `canAccessResourceField(...)` are for concrete UI/resource checks
+
+Do not treat Angular route metadata as full instance-level authorization. If the app has not loaded the resource yet, the Angular side can only make the coarse "attempt" decision. Nest still remains the final enforcement boundary for instance-sensitive access.
+
 ## Testing and Docs Workflow
 
 - Unit-test `state` and `feature` layers independently of primitive visuals.

--- a/docs/guides/nest.md
+++ b/docs/guides/nest.md
@@ -61,6 +61,19 @@ Contract ownership is TS-first:
 
 Nest libraries (`@anarchitects/forms-nest`, `@anarchitects/auth-nest`) map these contracts in presentation/application layers and keep schemas synchronized for OpenAPI generation. Ownership and compatibility policy are defined in [TS Contracts Guide](/guides/ts-contracts.html).
 
+## Auth CASL Guidance
+
+For `@anarchitects/auth-nest`, document and preserve the two-layer authorization model:
+
+- `@anarchitects/auth-ts` owns the `PolicyRule` shape
+- `@Policies()` is a coarse route-level pre-check over `{ action, subject }`
+- `@AuthorizeResource(...)` is the resource-aware path that loads the entity and evaluates the concrete CASL rule
+- `@AuthorizedResource()` exposes that already authorized entity to the handler
+
+This split is required for ownership-sensitive rules. Route metadata alone cannot prove that a user may update a specific post; the resource must be loaded before CASL can make that final decision.
+
+Malformed persisted permission payloads are treated as trust-boundary failures and must fail closed instead of being partially trusted.
+
 ## Library Entry Point Cookbook
 
 - Fast start:

--- a/libs/auth/angular/README.md
+++ b/libs/auth/angular/README.md
@@ -19,6 +19,17 @@ Angular domain libraries for the Anarchitecture auth domain. The package is orga
 - `util`: CASL ability helpers (`createAppAbility`, `canAccessResource`, `canAccessResourceField`, `AppAbility`)
 - `ui`: presentational auth domain form components built on `AnarchitectsUiForm`
 
+## Authorization Model
+
+CASL integration in `@anarchitects/auth-angular` mirrors the backend split instead of pretending every check is the same:
+
+- `policyGuard` is coarse and answers "may this user attempt work on this subject at all?"
+- `resourcePolicyGuard` checks a resolved concrete resource route
+- `canAccessResource(...)` and `canAccessResourceField(...)` are the intended UI checks for edit buttons, row actions, and field-sensitive affordances
+- `AuthStore` hydrates both raw `rbac` rules and the derived CASL ability
+
+Angular should hide or redirect on unauthorized work, but Nest remains the final enforcement boundary for instance-sensitive access.
+
 ## Installation
 
 ```bash
@@ -180,6 +191,7 @@ export class PostActionsComponent {
 - Data-access layer should always use the generated OpenAPI clients—no manual HTTP calls.
 - State layer uses Angular signals via `@ngrx/signals` for reactive updates, hydrates raw RBAC rules plus the derived CASL ability, and restores sessions eagerly when provided.
 - `AuthStore.initialized()` and `AuthStore.restoring()` let apps avoid auth flicker while bootstrap restore completes.
+- `/auth/me` RBAC payloads are parsed at the frontend trust boundary; malformed authorization data fails closed instead of producing a partially trusted ability.
 - Ability creation and concrete resource checks are centralised in `@anarchitects/auth-angular/util`; import the helpers instead of instantiating CASL directly.
 - `policyGuard` is coarse by design; use `resourcePolicyGuard` and backend instance checks for ownership-sensitive routes.
 - Keep UI, feature, data-access, state, and config layers decoupled per architecture guidelines.

--- a/libs/auth/angular/data-access/README.md
+++ b/libs/auth/angular/data-access/README.md
@@ -41,3 +41,13 @@ export const appConfig: ApplicationConfig = {
   providers: [provideHttpClient(withAuthHttpInterceptors())],
 };
 ```
+
+## Authorization Payload Expectations
+
+`AuthApi.getLoggedInUserInfo()` is the frontend trust boundary for `/auth/me` authorization data:
+
+- it expects `rbac` to match the shared `PolicyRule` contract from `@anarchitects/auth-ts`
+- malformed `rbac` payloads are rejected fail-closed before they reach `AuthStore`
+- bootstrap restore may suppress forced login redirects while still rejecting malformed authorization data
+
+Use the state and util layers for authorization behavior after this boundary rather than trusting raw HTTP JSON in feature/UI code.

--- a/libs/auth/angular/feature/README.md
+++ b/libs/auth/angular/feature/README.md
@@ -52,6 +52,15 @@ export const routes: Routes = [
 
 Use `resourcePolicyGuard` when the route already has the concrete entity in `route.data`. It evaluates the hydrated CASL ability against that loaded resource and redirects away when access is denied.
 
+This means a typical ownership-sensitive flow looks like this:
+
+- `policyGuard` allows the route attempt for `{ action, subject }`
+- `resourcePolicyGuard` checks the resolved entity when the route already has it
+- UI elements such as edit buttons still use `canAccessResource(...)` or `canAccessResourceField(...)`
+- the backend remains responsible for the final instance-level authorization decision
+
+Do not treat `policyGuard` as a full `PolicyRule` mirror. It is intentionally coarse.
+
 Ensure the state layer is explicitly provided in your app/route providers by wiring `...provideAuthState()` from `@anarchitects/auth-angular/state`.
 
 ### Token-driven actions

--- a/libs/auth/angular/state/README.md
+++ b/libs/auth/angular/state/README.md
@@ -58,3 +58,13 @@ After the first restore attempt completes or is skipped:
 - `store.rbac()` and `store.ability()` are hydrated when the session is valid
 
 Use `initialized()` to avoid protected-route flicker during app startup.
+
+## Authorization State Notes
+
+`AuthStore` is the Angular trust boundary for hydrated auth session state:
+
+- raw `rbac` rules are stored alongside the derived CASL ability
+- `/auth/me` authorization payloads are validated before the store trusts them
+- malformed RBAC during restore, login, or refresh fails closed by clearing the session instead of keeping partial authorization state
+
+Use `store.rbac()` for coarse route-attempt checks and `store.ability()` for concrete resource checks.

--- a/libs/auth/angular/util/README.md
+++ b/libs/auth/angular/util/README.md
@@ -9,6 +9,16 @@ Utility layer for Angular auth. Re-exported via `@anarchitects/auth-angular/util
 - `canAccessResourceField(...)`: checks whether a specific field-level action is allowed for a concrete resource.
 - `AppAbility`: CASL ability type configured for `Action`/`Subject` pairs defined in `@anarchitects/auth-ts/models`.
 
+## When To Use These Helpers
+
+Use this layer for concrete resource decisions, not coarse route metadata:
+
+- `createAppAbility(rules)` builds the frontend CASL ability from validated RBAC rules
+- `canAccessResource(...)` answers instance-level questions such as "may this user edit this post?"
+- `canAccessResourceField(...)` answers field-sensitive UI questions such as inline title editing
+
+If you only need coarse route-attempt semantics, use `policyGuard` and `RoutePolicy` instead of calling CASL directly here.
+
 ## Usage
 
 ```ts

--- a/libs/auth/nest/README.md
+++ b/libs/auth/nest/README.md
@@ -37,8 +37,8 @@ The internal `@anarchitects/auth-ts` and `@anarchitects/common-nest-mailer` pack
 | Import path                                          | Contents                                                                                                                                         |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `@anarchitects/auth-nest`                            | `AuthModule.forRoot(...)`, `AuthModule.forRootFromConfig(...)`, plus re-exports of layered entry points for convenience                          |
-| `@anarchitects/auth-nest/application`                | `AuthApplicationModule`, `AuthService`, `JwtAuthService`, `HashService`, `BcryptHashService`, `PoliciesService`, `AbilityFactory`, `JwtStrategy` |
-| `@anarchitects/auth-nest/presentation`               | `AuthPresentationModule`, `AuthController`, `PoliciesGuard`, `@Policies()` decorator                                                             |
+| `@anarchitects/auth-nest/application`                | `AuthApplicationModule`, `AuthService`, `JwtAuthService`, `HashService`, `BcryptHashService`, `PoliciesService`, `AbilityFactory`, `JwtStrategy`, resource-authorization helpers/types |
+| `@anarchitects/auth-nest/presentation`               | `AuthPresentationModule`, `AuthController`, `PoliciesGuard`, `ResourceAuthorizationGuard`, `@Policies()`, `@AuthorizeResource()`, `@AuthorizedResource()`, `RoutePolicy` |
 | `@anarchitects/auth-nest/infrastructure-persistence` | `AuthPersistenceModule`, `AuthUserRepository`, `TypeormAuthUserRepository`, migration                                                            |
 | `@anarchitects/auth-nest/infrastructure-mailer`      | `AuthMailerModule`, `NodeMailerAdapter`                                                                                                          |
 | `@anarchitects/auth-nest/config`                     | `authConfig`, `AuthConfig` type, `InjectAuthConfig()`                                                                                            |
@@ -262,6 +262,32 @@ AuthModule.forRoot({
 
 `@Policies()` remains the coarse route-level pre-check. `@AuthorizeResource(...)` uses the app-registered loader to fetch the concrete entity, evaluates the instance-level CASL rule behind the scenes, and attaches the authorized resource to the request so `@AuthorizedResource()` can read it in the handler.
 
+## Authorization Model
+
+CASL integration in `@anarchitects/auth-nest` is intentionally split into two layers:
+
+- `@Policies()` uses `RoutePolicy` and performs a coarse route-level pre-check
+- `@AuthorizeResource(...)` performs the concrete instance-level check after loading the resource
+- `@AuthorizedResource()` gives the handler access to the already loaded and authorized entity
+
+Use this split to avoid overstating what route metadata can prove. Ownership-sensitive rules such as "writers may only update their own posts" need the concrete resource instance before CASL can decide correctly.
+
+### What the library enforces
+
+- persisted permission payloads are validated before they become `PolicyRule[]`
+- malformed persisted permission payloads fail closed with a server-side error
+- missing registered resource loader is treated as configuration error
+- missing route param yields `400`
+- missing resource yields `404`
+
+### What the host app must provide
+
+- subject-specific resource loaders for `@AuthorizeResource(...)`
+- domain resource retrieval logic and repository access
+- route resolver/handler composition that fits the app's domain model
+
+The library owns authorization orchestration. The host app still owns how domain resources are found.
+
 ## REST endpoints
 
 The `AuthController` exposes the following routes (all prefixed with `/auth`):
@@ -292,6 +318,7 @@ The `AuthController` exposes the following routes (all prefixed with `/auth`):
 - Default persistence is TypeORM with schema-qualified tables (see `libs/auth/nest/src/infrastructure-persistence`).
 - Invalidated tokens use an unlogged cache table for quick revocation lookups.
 - Route schemas are defined in `@anarchitects/auth-ts/dtos` and imported into controller `@RouteSchema` decorators — do not define inline schemas.
+- Keep `@Policies()` guidance coarse in docs and examples; use `@AuthorizeResource(...)` for instance-sensitive authorization.
 - OpenAPI metadata (`operationId`, `tags`) is assigned in `tools/api-specs/route-metadata.ts`, not in controllers.
 
 ## License

--- a/libs/auth/ts/README.md
+++ b/libs/auth/ts/README.md
@@ -21,6 +21,31 @@ Use it to validate inbound/outbound payloads, share typings between Angular/Nest
 - Domain model contracts for users, roles, and permissions
 - Reusable validation + type-inference building blocks for auth flows
 
+## Authorization Contract
+
+`@anarchitects/auth-ts` is the source of truth for serialized auth rule shape, but it does not enforce frontend or backend authorization by itself.
+
+### `PolicyRule`
+
+Serialized RBAC rules use the following contract:
+
+- required: `action`, `subject`
+- optional: `conditions`, `fields`, `inverted`, `reason`
+- `action` and `subject` stay open strings for compatibility across apps
+- malformed rule payloads are rejected fail-closed by the shared DTO parsers
+
+This is the contract emitted by `/auth/me`, persisted through auth permission mapping, and consumed by Angular/Nest authorization helpers.
+
+### `RoutePolicy`
+
+`RoutePolicy` is intentionally narrower than `PolicyRule`:
+
+- shape: `{ action, subject }`
+- purpose: coarse route-attempt checks
+- not a substitute for instance-level authorization
+
+Use `RoutePolicy` when a consumer only needs to answer "may this user attempt this kind of work at all?" Concrete ownership or field-sensitive checks still belong to loaded resources and CASL ability evaluation in Angular/Nest layers.
+
 ## Installation
 
 ```bash
@@ -99,6 +124,7 @@ The models include timestamps (`createdAt`, `updatedAt`) and bidirectional relat
 ## Development notes
 
 - Treat this package as the source of truth for auth DTO and model contracts.
+- Use `parsePolicyRuleDTO(...)` / `parsePolicyRuleArrayDTO(...)` when authorization rules cross trust boundaries and need runtime validation.
 - When changing DTO schemas, regenerate OpenAPI in the workspace (`nx run api-specs:generate`).
 - Keep framework-specific concerns out of this package; Angular/Nest behavior belongs in domain libraries.
 


### PR DESCRIPTION
Document the current CASL integration model across auth-ts, auth-nest, and auth-angular so consumers understand the shared rule shape, enforcement boundaries, and host-app responsibilities.

- document the serialized PolicyRule contract and RoutePolicy distinction in auth-ts
- update auth-nest exports and add explicit guidance for coarse route checks vs resource-aware authorization
- document loader responsibilities, 404 behavior, and fail-closed malformed permission handling in auth-nest
- align auth-angular root and layer READMEs around policyGuard, resourcePolicyGuard, AuthStore hydration, and UI resource checks
- explain frontend fail-closed handling for malformed /auth/me rbac payloads
- add auth-specific CASL guidance to the Angular and Nest docs-hub guides so package READMEs and guides stay consistent

Closes #115 Refs #108