### PR TITLE
chore(eslint): add explicit domain dependency constraints

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,35 @@ export default [
           allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$'],
           depConstraints: [
             {
-              sourceTag: '*',
+              sourceTag: 'domain:shared',
+              onlyDependOnLibsWithTags: ['domain:shared'],
+            },
+            {
+              sourceTag: 'domain:forms',
+              onlyDependOnLibsWithTags: ['domain:shared', 'domain:forms'],
+            },
+            {
+              sourceTag: 'domain:auth',
+              onlyDependOnLibsWithTags: [
+                'domain:shared',
+                'domain:forms',
+                'domain:auth',
+              ],
+            },
+            {
+              sourceTag: 'domain:storybook',
+              onlyDependOnLibsWithTags: ['*'],
+            },
+            {
+              sourceTag: 'scope:docs',
+              onlyDependOnLibsWithTags: ['*'],
+            },
+            {
+              sourceTag: 'scope:release',
+              onlyDependOnLibsWithTags: ['*'],
+            },
+            {
+              sourceTag: 'scope:ts-frontend',
               onlyDependOnLibsWithTags: ['*'],
             },
           ],


### PR DESCRIPTION
Add Nx enforce-module-boundaries rules so:
- shared depends only on shared
- forms depends on shared and forms
- auth depends on shared, forms, and auth

Also add explicit permissive constraints for non-domain tooling sources that are out of scope for SI-110.1, avoiding unintended lint failures for storybook and docs projects.

Closes #116 Refs #110