### PR TITLE
refactor(auth-angular): centralize auth form bridge mapping seam

### DIFF
--- a/libs/auth/angular/ui/src/components/activate-user-form/activate-user-form.ts
+++ b/libs/auth/angular/ui/src/components/activate-user-form/activate-user-form.ts
@@ -1,7 +1,6 @@
 import { ActivateUserRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -10,6 +9,7 @@ import {
   output,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { activateUserFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-activate-user-form',
@@ -28,27 +28,16 @@ export class AnarchitectsAuthUiActivateUserForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ActivateUserRequestDTO>();
 
-  readonly formConfig = computed<FormConfig>(() => ({
-    id: 'activate-user',
-    version: 1,
-    fields: [
-      {
-        name: 'token',
-        kind: 'string',
-        required: !this.token(),
-        minLength: 1,
-        ui: { label: 'Activation Token' },
-      },
-    ],
-  }));
+  readonly formConfig = computed(() =>
+    activateUserFormBridge.resolveFormConfig({ token: this.token() }),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const token =
-      (input.payload['token'] as string | undefined) || this.token();
-    if (!token) {
-      return;
+    const dto = activateUserFormBridge.mapSubmission(input, {
+      token: this.token(),
+    });
+    if (dto) {
+      this.submitted.emit(dto);
     }
-
-    this.submitted.emit({ token });
   }
 }

--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
@@ -1,15 +1,15 @@
 import { ChangePasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { changePasswordFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-change-password-form',
@@ -27,47 +27,14 @@ export class AnarchitectsAuthUiChangePasswordForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ChangePasswordRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'change-password',
-    version: 1,
-    fields: [
-      {
-        name: 'currentPassword',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Current Password' },
-      },
-      {
-        name: 'newPassword',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'New Password' },
-      },
-      {
-        name: 'confirmPassword',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Confirm Password' },
-      },
-    ],
-    validationRules: [
-      {
-        kind: 'matchFields',
-        sourceField: 'newPassword',
-        targetField: 'confirmPassword',
-        message: 'Passwords must match.',
-      },
-    ],
-  });
+  readonly formConfig = computed(() =>
+    changePasswordFormBridge.resolveFormConfig(),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    this.submitted.emit({
-      currentPassword: input.payload['currentPassword'] as string,
-      newPassword: input.payload['newPassword'] as string,
-      confirmPassword: input.payload['confirmPassword'] as string,
-    });
+    const dto = changePasswordFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.ts
+++ b/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.ts
@@ -1,15 +1,15 @@
 import { ForgotPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { forgotPasswordFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-forgot-password-form',
@@ -27,22 +27,14 @@ export class AnarchitectsAuthUiForgotPasswordForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ForgotPasswordRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'forgot-password',
-    version: 1,
-    fields: [
-      {
-        name: 'email',
-        kind: 'email',
-        required: true,
-        ui: { label: 'Email' },
-      },
-    ],
-  });
+  readonly formConfig = computed(() =>
+    forgotPasswordFormBridge.resolveFormConfig(),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    this.submitted.emit({
-      email: input.payload['email'] as string,
-    });
+    const dto = forgotPasswordFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/login-form/login-form.ts
+++ b/libs/auth/angular/ui/src/components/login-form/login-form.ts
@@ -1,15 +1,15 @@
 import { LoginRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { loginFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-login-form',
@@ -27,32 +27,12 @@ export class AnarchitectsAuthUiLoginForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<LoginRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'login',
-    version: 1,
-    fields: [
-      {
-        name: 'credential',
-        kind: 'string',
-        required: true,
-        minLength: 2,
-        maxLength: 100,
-        ui: { label: 'Email or Username' },
-      },
-      {
-        name: 'password',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Password' },
-      },
-    ],
-  });
+  readonly formConfig = computed(() => loginFormBridge.resolveFormConfig());
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    this.submitted.emit({
-      credential: input.payload['credential'] as string,
-      password: input.payload['password'] as string,
-    });
+    const dto = loginFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/logout-form/logout-form.ts
+++ b/libs/auth/angular/ui/src/components/logout-form/logout-form.ts
@@ -1,15 +1,15 @@
 import { LogoutRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { logoutFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-logout-form',
@@ -27,44 +27,12 @@ export class AnarchitectsAuthUiLogoutForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<LogoutRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'logout',
-    version: 1,
-    fields: [
-      {
-        name: 'refreshToken',
-        kind: 'string',
-        required: false,
-        minLength: 1,
-        ui: { label: 'Refresh Token' },
-      },
-      {
-        name: 'accessToken',
-        kind: 'string',
-        required: false,
-        minLength: 1,
-        ui: { label: 'Access Token (optional)' },
-      },
-    ],
-  });
+  readonly formConfig = computed(() => logoutFormBridge.resolveFormConfig());
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const refreshToken =
-      (input.payload['refreshToken'] as string | undefined) ||
-      localStorage.getItem('refreshToken') ||
-      undefined;
-    const accessToken =
-      (input.payload['accessToken'] as string | undefined) ||
-      localStorage.getItem('accessToken') ||
-      undefined;
-
-    if (!refreshToken) {
-      return;
+    const dto = logoutFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
     }
-
-    this.submitted.emit({
-      refreshToken,
-      ...(accessToken ? { accessToken } : {}),
-    });
   }
 }

--- a/libs/auth/angular/ui/src/components/refresh-tokens-form/refresh-tokens-form.ts
+++ b/libs/auth/angular/ui/src/components/refresh-tokens-form/refresh-tokens-form.ts
@@ -1,15 +1,15 @@
 import { RefreshTokenRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { refreshTokensFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-refresh-tokens-form',
@@ -27,30 +27,14 @@ export class AnarchitectsAuthUiRefreshTokensForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<RefreshTokenRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'refresh-tokens',
-    version: 1,
-    fields: [
-      {
-        name: 'refreshToken',
-        kind: 'string',
-        required: false,
-        minLength: 1,
-        ui: { label: 'Refresh Token' },
-      },
-    ],
-  });
+  readonly formConfig = computed(() =>
+    refreshTokensFormBridge.resolveFormConfig(),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const refreshToken =
-      (input.payload['refreshToken'] as string | undefined) ||
-      localStorage.getItem('refreshToken') ||
-      undefined;
-
-    if (!refreshToken) {
-      return;
+    const dto = refreshTokensFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
     }
-
-    this.submitted.emit({ refreshToken });
   }
 }

--- a/libs/auth/angular/ui/src/components/register-form/register-form.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.ts
@@ -1,15 +1,15 @@
 import { RegisterRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { registerFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-register-form',
@@ -27,46 +27,12 @@ export class AnarchitectsAuthUiRegisterForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<RegisterRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'register',
-    version: 1,
-    fields: [
-      {
-        name: 'userName',
-        kind: 'string',
-        ui: { label: 'Username' },
-        required: false,
-      },
-      { name: 'email', kind: 'email', ui: { label: 'Email' }, required: true },
-      {
-        name: 'password',
-        kind: 'password',
-        ui: { label: 'Password' },
-        required: true,
-      },
-      {
-        name: 'confirmPassword',
-        kind: 'password',
-        ui: { label: 'Confirm Password' },
-        required: true,
-      },
-    ],
-    validationRules: [
-      {
-        kind: 'matchFields',
-        sourceField: 'password',
-        targetField: 'confirmPassword',
-        message: 'Passwords must match.',
-      },
-    ],
-  });
+  readonly formConfig = computed(() => registerFormBridge.resolveFormConfig());
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    this.submitted.emit({
-      userName: input.payload['userName'] as string | undefined,
-      email: input.payload['email'] as string,
-      password: input.payload['password'] as string,
-      confirmPassword: input.payload['confirmPassword'] as string,
-    });
+    const dto = registerFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
@@ -1,7 +1,6 @@
 import { ResetPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -10,6 +9,7 @@ import {
   output,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { resetPasswordFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-reset-password-form',
@@ -28,53 +28,16 @@ export class AnarchitectsAuthUiResetPasswordForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ResetPasswordRequestDTO>();
 
-  readonly formConfig = computed<FormConfig>(() => ({
-    id: 'reset-password',
-    version: 1,
-    fields: [
-      {
-        name: 'token',
-        kind: 'string',
-        required: !this.token(),
-        minLength: 1,
-        ui: { label: 'Reset Token' },
-      },
-      {
-        name: 'password',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Password' },
-      },
-      {
-        name: 'confirmPassword',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Confirm Password' },
-      },
-    ],
-    validationRules: [
-      {
-        kind: 'matchFields',
-        sourceField: 'password',
-        targetField: 'confirmPassword',
-        message: 'Passwords must match.',
-      },
-    ],
-  }));
+  readonly formConfig = computed(() =>
+    resetPasswordFormBridge.resolveFormConfig({ token: this.token() }),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const token =
-      (input.payload['token'] as string | undefined) || this.token();
-    if (!token) {
-      return;
-    }
-
-    this.submitted.emit({
-      token,
-      password: input.payload['password'] as string,
-      confirmPassword: input.payload['confirmPassword'] as string,
+    const dto = resetPasswordFormBridge.mapSubmission(input, {
+      token: this.token(),
     });
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/update-email-form/update-email-form.ts
+++ b/libs/auth/angular/ui/src/components/update-email-form/update-email-form.ts
@@ -1,15 +1,15 @@
 import { UpdateEmailRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
-  signal,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { updateEmailFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-update-email-form',
@@ -27,30 +27,12 @@ export class AnarchitectsAuthUiUpdateEmailForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<UpdateEmailRequestDTO>();
 
-  readonly formConfig = signal<FormConfig>({
-    id: 'update-email',
-    version: 1,
-    fields: [
-      {
-        name: 'newEmail',
-        kind: 'email',
-        required: true,
-        ui: { label: 'New Email' },
-      },
-      {
-        name: 'password',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Password' },
-      },
-    ],
-  });
+  readonly formConfig = computed(() => updateEmailFormBridge.resolveFormConfig());
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    this.submitted.emit({
-      newEmail: input.payload['newEmail'] as string,
-      password: input.payload['password'] as string | undefined,
-    });
+    const dto = updateEmailFormBridge.mapSubmission(input);
+    if (dto) {
+      this.submitted.emit(dto);
+    }
   }
 }

--- a/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.ts
+++ b/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.ts
@@ -1,7 +1,6 @@
 import { VerifyEmailRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -10,6 +9,7 @@ import {
   output,
 } from '@angular/core';
 import type { AnxLayoutId } from '@anarchitects/common-angular-ui-layouts/contracts';
+import { verifyEmailFormBridge } from '../../internal/auth-form-bridges';
 
 @Component({
   selector: 'anarchitects-auth-ui-verify-email-form',
@@ -28,27 +28,16 @@ export class AnarchitectsAuthUiVerifyEmailForm {
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<VerifyEmailRequestDTO>();
 
-  readonly formConfig = computed<FormConfig>(() => ({
-    id: 'verify-email',
-    version: 1,
-    fields: [
-      {
-        name: 'token',
-        kind: 'string',
-        required: !this.token(),
-        minLength: 1,
-        ui: { label: 'Verification Token' },
-      },
-    ],
-  }));
+  readonly formConfig = computed(() =>
+    verifyEmailFormBridge.resolveFormConfig({ token: this.token() }),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const token =
-      (input.payload['token'] as string | undefined) || this.token();
-    if (!token) {
-      return;
+    const dto = verifyEmailFormBridge.mapSubmission(input, {
+      token: this.token(),
+    });
+    if (dto) {
+      this.submitted.emit(dto);
     }
-
-    this.submitted.emit({ token });
   }
 }

--- a/libs/auth/angular/ui/src/internal/auth-form-bridges.ts
+++ b/libs/auth/angular/ui/src/internal/auth-form-bridges.ts
@@ -1,0 +1,369 @@
+import {
+  ActivateUserRequestDTO,
+  ChangePasswordRequestDTO,
+  ForgotPasswordRequestDTO,
+  LoginRequestDTO,
+  LogoutRequestDTO,
+  RefreshTokenRequestDTO,
+  RegisterRequestDTO,
+  ResetPasswordRequestDTO,
+  UpdateEmailRequestDTO,
+  VerifyEmailRequestDTO,
+} from '@anarchitects/auth-ts/dtos';
+import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
+import { FormConfig } from '@anarchitects/forms-ts/models';
+
+type TokenContext = Readonly<{
+  token?: string;
+}>;
+
+interface AuthFormBridge<TDto, TContext = undefined> {
+  resolveFormConfig(context?: TContext): FormConfig;
+  mapSubmission(
+    input: SubmissionRequestDTO,
+    context?: TContext,
+  ): TDto | undefined;
+}
+
+const readPayloadString = (
+  input: SubmissionRequestDTO,
+  key: string,
+): string | undefined => input.payload[key] as string | undefined;
+
+const readStoredString = (key: string): string | undefined =>
+  localStorage.getItem(key) || undefined;
+
+const matchFieldsRule = (sourceField: string, targetField: string) => ({
+  kind: 'matchFields' as const,
+  sourceField,
+  targetField,
+  message: 'Passwords must match.',
+});
+
+const LOGIN_FORM_CONFIG: FormConfig = {
+  id: 'login',
+  version: 1,
+  fields: [
+    {
+      name: 'credential',
+      kind: 'string',
+      required: true,
+      minLength: 2,
+      maxLength: 100,
+      ui: { label: 'Email or Username' },
+    },
+    {
+      name: 'password',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: { label: 'Password' },
+    },
+  ],
+};
+
+const REGISTER_FORM_CONFIG: FormConfig = {
+  id: 'register',
+  version: 1,
+  fields: [
+    {
+      name: 'userName',
+      kind: 'string',
+      ui: { label: 'Username' },
+      required: false,
+    },
+    { name: 'email', kind: 'email', ui: { label: 'Email' }, required: true },
+    {
+      name: 'password',
+      kind: 'password',
+      ui: { label: 'Password' },
+      required: true,
+    },
+    {
+      name: 'confirmPassword',
+      kind: 'password',
+      ui: { label: 'Confirm Password' },
+      required: true,
+    },
+  ],
+  validationRules: [matchFieldsRule('password', 'confirmPassword')],
+};
+
+const CHANGE_PASSWORD_FORM_CONFIG: FormConfig = {
+  id: 'change-password',
+  version: 1,
+  fields: [
+    {
+      name: 'currentPassword',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: { label: 'Current Password' },
+    },
+    {
+      name: 'newPassword',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: { label: 'New Password' },
+    },
+    {
+      name: 'confirmPassword',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: { label: 'Confirm Password' },
+    },
+  ],
+  validationRules: [matchFieldsRule('newPassword', 'confirmPassword')],
+};
+
+const FORGOT_PASSWORD_FORM_CONFIG: FormConfig = {
+  id: 'forgot-password',
+  version: 1,
+  fields: [
+    {
+      name: 'email',
+      kind: 'email',
+      required: true,
+      ui: { label: 'Email' },
+    },
+  ],
+};
+
+const UPDATE_EMAIL_FORM_CONFIG: FormConfig = {
+  id: 'update-email',
+  version: 1,
+  fields: [
+    {
+      name: 'newEmail',
+      kind: 'email',
+      required: true,
+      ui: { label: 'New Email' },
+    },
+    {
+      name: 'password',
+      kind: 'password',
+      required: true,
+      minLength: 6,
+      ui: { label: 'Password' },
+    },
+  ],
+};
+
+const LOGOUT_FORM_CONFIG: FormConfig = {
+  id: 'logout',
+  version: 1,
+  fields: [
+    {
+      name: 'refreshToken',
+      kind: 'string',
+      required: false,
+      minLength: 1,
+      ui: { label: 'Refresh Token' },
+    },
+    {
+      name: 'accessToken',
+      kind: 'string',
+      required: false,
+      minLength: 1,
+      ui: { label: 'Access Token (optional)' },
+    },
+  ],
+};
+
+const REFRESH_TOKENS_FORM_CONFIG: FormConfig = {
+  id: 'refresh-tokens',
+  version: 1,
+  fields: [
+    {
+      name: 'refreshToken',
+      kind: 'string',
+      required: false,
+      minLength: 1,
+      ui: { label: 'Refresh Token' },
+    },
+  ],
+};
+
+const resolveToken = (
+  input: SubmissionRequestDTO,
+  fallbackToken?: string,
+): string | undefined => readPayloadString(input, 'token') || fallbackToken;
+
+export const loginFormBridge: AuthFormBridge<LoginRequestDTO> = {
+  resolveFormConfig: () => LOGIN_FORM_CONFIG,
+  mapSubmission: (input) => ({
+    credential: readPayloadString(input, 'credential') as string,
+    password: readPayloadString(input, 'password') as string,
+  }),
+};
+
+export const registerFormBridge: AuthFormBridge<RegisterRequestDTO> = {
+  resolveFormConfig: () => REGISTER_FORM_CONFIG,
+  mapSubmission: (input) => ({
+    userName: readPayloadString(input, 'userName'),
+    email: readPayloadString(input, 'email') as string,
+    password: readPayloadString(input, 'password') as string,
+    confirmPassword: readPayloadString(input, 'confirmPassword') as string,
+  }),
+};
+
+export const activateUserFormBridge: AuthFormBridge<
+  ActivateUserRequestDTO,
+  TokenContext
+> = {
+  resolveFormConfig: (context) => ({
+    id: 'activate-user',
+    version: 1,
+    fields: [
+      {
+        name: 'token',
+        kind: 'string',
+        required: !context?.token,
+        minLength: 1,
+        ui: { label: 'Activation Token' },
+      },
+    ],
+  }),
+  mapSubmission: (input, context) => {
+    const token = resolveToken(input, context?.token);
+    if (!token) {
+      return undefined;
+    }
+
+    return { token };
+  },
+};
+
+export const forgotPasswordFormBridge: AuthFormBridge<ForgotPasswordRequestDTO> =
+  {
+    resolveFormConfig: () => FORGOT_PASSWORD_FORM_CONFIG,
+    mapSubmission: (input) => ({
+      email: readPayloadString(input, 'email') as string,
+    }),
+  };
+
+export const resetPasswordFormBridge: AuthFormBridge<
+  ResetPasswordRequestDTO,
+  TokenContext
+> = {
+  resolveFormConfig: (context) => ({
+    id: 'reset-password',
+    version: 1,
+    fields: [
+      {
+        name: 'token',
+        kind: 'string',
+        required: !context?.token,
+        minLength: 1,
+        ui: { label: 'Reset Token' },
+      },
+      {
+        name: 'password',
+        kind: 'password',
+        required: true,
+        minLength: 6,
+        ui: { label: 'Password' },
+      },
+      {
+        name: 'confirmPassword',
+        kind: 'password',
+        required: true,
+        minLength: 6,
+        ui: { label: 'Confirm Password' },
+      },
+    ],
+    validationRules: [matchFieldsRule('password', 'confirmPassword')],
+  }),
+  mapSubmission: (input, context) => {
+    const token = resolveToken(input, context?.token);
+    if (!token) {
+      return undefined;
+    }
+
+    return {
+      token,
+      password: readPayloadString(input, 'password') as string,
+      confirmPassword: readPayloadString(input, 'confirmPassword') as string,
+    };
+  },
+};
+
+export const verifyEmailFormBridge: AuthFormBridge<
+  VerifyEmailRequestDTO,
+  TokenContext
+> = {
+  resolveFormConfig: (context) => ({
+    id: 'verify-email',
+    version: 1,
+    fields: [
+      {
+        name: 'token',
+        kind: 'string',
+        required: !context?.token,
+        minLength: 1,
+        ui: { label: 'Verification Token' },
+      },
+    ],
+  }),
+  mapSubmission: (input, context) => {
+    const token = resolveToken(input, context?.token);
+    if (!token) {
+      return undefined;
+    }
+
+    return { token };
+  },
+};
+
+export const changePasswordFormBridge: AuthFormBridge<ChangePasswordRequestDTO> =
+  {
+    resolveFormConfig: () => CHANGE_PASSWORD_FORM_CONFIG,
+    mapSubmission: (input) => ({
+      currentPassword: readPayloadString(input, 'currentPassword') as string,
+      newPassword: readPayloadString(input, 'newPassword') as string,
+      confirmPassword: readPayloadString(input, 'confirmPassword') as string,
+    }),
+  };
+
+export const updateEmailFormBridge: AuthFormBridge<UpdateEmailRequestDTO> = {
+  resolveFormConfig: () => UPDATE_EMAIL_FORM_CONFIG,
+  mapSubmission: (input) => ({
+    newEmail: readPayloadString(input, 'newEmail') as string,
+    password: readPayloadString(input, 'password'),
+  }),
+};
+
+export const logoutFormBridge: AuthFormBridge<LogoutRequestDTO> = {
+  resolveFormConfig: () => LOGOUT_FORM_CONFIG,
+  mapSubmission: (input) => {
+    const refreshToken =
+      readPayloadString(input, 'refreshToken') || readStoredString('refreshToken');
+    const accessToken =
+      readPayloadString(input, 'accessToken') || readStoredString('accessToken');
+
+    if (!refreshToken) {
+      return undefined;
+    }
+
+    return {
+      refreshToken,
+      ...(accessToken ? { accessToken } : {}),
+    };
+  },
+};
+
+export const refreshTokensFormBridge: AuthFormBridge<RefreshTokenRequestDTO> = {
+  resolveFormConfig: () => REFRESH_TOKENS_FORM_CONFIG,
+  mapSubmission: (input) => {
+    const refreshToken =
+      readPayloadString(input, 'refreshToken') || readStoredString('refreshToken');
+
+    if (!refreshToken) {
+      return undefined;
+    }
+
+    return { refreshToken };
+  },
+};


### PR DESCRIPTION
Extract auth form config resolution and SubmissionRequestDTO to auth DTO mapping into a shared internal bridge module for auth-angular/ui.

Update the auth UI form components to delegate to the shared bridge so token fallback, local-storage fallback, and match-field config logic are defined once instead of being repeated across individual components.

Validated with:
- yarn nx run auth-angular:test
- yarn nx run auth-angular:lint
- yarn nx run auth-angular:build

Closes #118 Refs #110