### PR TITLE
docs(auth): finalize better-auth decision ADRs for conditional go

### DIFF
--- a/docs/adr/106-better-auth-spike.md
+++ b/docs/adr/106-better-auth-spike.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Decision-ready, pending final human confirmation.
+Accepted - Conditional GO.
 
 ## Context
 
@@ -51,38 +51,33 @@ The spike and follow-on sub-issues established the following:
   native dynamic `import()` without forcing a package-format migration during
   the spike.
 
-### Persistence recommendation
+### Persistence strategy
 
 - Persistence fit was analyzed separately in [ADR 121](./121-better-auth-persistence-recommendation.md).
-- The preferred path is isolated Better Auth-owned persistence.
-- A custom Better Auth TypeORM adapter remains an explicit fallback only, not
-  the default recommendation.
+- The accepted model is configuration-driven and abstracted behind an
+  application-layer persistence port.
+- Supported Better Auth persistence modes are:
+  - `isolated`
+  - `typeorm-adapter`
+- The default Better Auth persistence mode is `isolated`.
+- The `isolated` mode supports both:
+  - `same-db`
+  - `separate-db`
+- The default isolated topology is `same-db`.
 
 ## Decision Outcome
 
-Final human confirmation is still required.
+- Final outcome: `Conditional GO`
 
-Current default interpretation of the evidence:
-
-- **Recommended outcome:** `Conditional GO`
-
-Confirmed decision slot:
-
-- Final outcome: `TO BE CONFIRMED BY HUMAN REVIEW`
-- Allowed final values:
-  - `GO`
-  - `Conditional GO`
-  - `NO-GO`
-
-Rationale for the current default interpretation:
+Rationale for the final outcome:
 
 - Better Auth appears viable as an internal engine candidate behind
   `AuthEnginePort`.
 - Public package APIs remained framework-agnostic through the spike and
   boundary work.
 - The remaining concerns are implementation constraints, not spike failure:
-  persistence ownership, session-vs-JWT mapping decisions, and continued public
-  API containment.
+  configuration-driven persistence composition, session-vs-JWT mapping
+  decisions, and continued public API containment.
 
 ## Finalized Conclusions
 
@@ -103,10 +98,21 @@ Rationale for the current default interpretation:
 
 ### Persistence direction
 
-- Preferred path: isolated Better Auth-owned persistence internal to
-  `auth-nest`.
-- Fallback path: custom Better Auth TypeORM adapter, only if isolated
-  persistence becomes operationally unacceptable.
+- Better Auth remains internal to `auth-nest`.
+- Better Auth persistence must remain abstracted behind an application-layer
+  port.
+- Persistence mode is configuration-driven.
+- Supported Better Auth persistence modes are:
+  - `isolated`
+  - `typeorm-adapter`
+- Default Better Auth persistence mode: `isolated`.
+- Supported isolated topologies are:
+  - `same-db`
+  - `separate-db`
+- Default isolated topology: `same-db`.
+- The custom TypeORM adapter starts as an internal repo implementation and may
+  later be extracted to an Anarchitects community repo once the contract and
+  maintenance shape are stable.
 - Current TypeORM legacy JWT persistence remains the default and should not be
   remapped to Better Auth tables by default.
 
@@ -129,12 +135,18 @@ follow-on implementation:
 If the final outcome is `GO` or `Conditional GO`:
 
 - Create a separate follow-on implementation parent issue/epic.
+- Create a separate parallel parent issue for Anarchitects community Better
+  Auth integrations.
 - Keep `legacy-jwt` as the default engine until that follow-on implementation
   lands and is explicitly approved.
 - Treat passkeys, social flows, DTO additions, Better Auth persistence tables,
   Angular integration, and docs/contract updates as follow-on work.
-- Apply the isolated Better Auth persistence recommendation from ADR 121 unless
-  the fallback trigger is explicitly met.
+- When `engine=better-auth`, default the persistence mode to `isolated`.
+- When `engine=better-auth` and `persistence.mode=isolated`, default the
+  topology to `same-db`.
+- Support the internal TypeORM adapter in parallel as a configuration-driven
+  Better Auth persistence mode, while incubating its extraction path in the
+  community repo track.
 
 If the final outcome is `NO-GO`:
 
@@ -143,21 +155,3 @@ If the final outcome is `NO-GO`:
 - Keep the repo on the `legacy-jwt` engine path.
 - Treat the completed spike/boundary work as closed evaluation effort rather
   than migration start.
-
-## Final Decision To Be Confirmed
-
-Before closing `#123` and `#106`, a human should edit this ADR and replace:
-
-- `Final outcome: TO BE CONFIRMED BY HUMAN REVIEW`
-
-with one of:
-
-- `Final outcome: GO`
-- `Final outcome: Conditional GO`
-- `Final outcome: NO-GO`
-
-At the same time, update the `Status` section from:
-
-- `Decision-ready, pending final human confirmation.`
-
-to the final decision status that matches the chosen outcome.

--- a/docs/adr/121-better-auth-persistence-recommendation.md
+++ b/docs/adr/121-better-auth-persistence-recommendation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -108,63 +108,66 @@ Main downside:
 - It is a framework-integration product of its own, not just an app-level
   implementation choice.
 
-## Constraints That Must Hold For Either Option
+## Accepted Strategy
+
+Accept a **dual-path Better Auth persistence strategy** for this repo.
+
+Accepted modes:
+
+- `isolated`: isolated Better Auth-owned persistence
+- `typeorm-adapter`: custom Anarchitects-owned Better Auth TypeORM adapter
+
+Defaults:
+
+- Default Better Auth persistence mode: `isolated`
+- Supported isolated topologies:
+  - `same-db`
+  - `separate-db`
+- Default isolated topology: `same-db`
+
+Reasoning:
+
+- It preserves the architectural goal from `#106`: adopt Better Auth behind the
+  existing facades without forcing framework persistence details into the public
+  package surface.
+- It keeps the cleanest default boundary between current TypeORM legacy JWT
+  persistence and future Better Auth persistence concerns.
+- It still supports a TypeORM-native Better Auth path for hosts or deployments
+  that benefit from a single ORM control plane.
+- It aligns with the repo flexibility paradigm by making persistence strategy
+  application-layer-abstracted and configuration-driven rather than hardwired.
+
+## Delivery Shape
+
+- The TypeORM adapter starts as an internal implementation in this repo.
+- The isolated Better Auth path and the internal TypeORM adapter path are both
+  supported follow-on implementation tracks.
+- The TypeORM adapter is not public package surface in the first implementation
+  phase.
+- In parallel, Anarchitects should start work on a community repo path for the
+  adapter, but community packaging must follow internal contract proof rather
+  than lead it.
+
+## Constraints That Remain Non-Negotiable
 
 - No public `auth-ts` models should be changed to mirror Better Auth tables.
 - No public DTO or route contract should become Better Auth persistence-shaped.
 - Better Auth persistence must remain internal to `auth-nest`.
 - Cross-domain persistence expansion must not be introduced.
-- The current `AuthEnginePort` seam remains the runtime boundary; persistence
-  decisions must not bypass it by coupling controllers or public contracts to a
-  storage model.
-
-## Recommendation
-
-Recommend **Option A: isolated Better Auth-owned persistence** as the preferred
-path for this repo.
-
-Reasoning:
-
-- It best matches the architectural goal from `#106`: evaluate and potentially
-  adopt Better Auth behind the existing facades without forcing framework
-  internals into the public package surface.
-- It avoids turning Anarchitects into the maintainer of a Better Auth
-  infrastructure product before Better Auth has even been adopted as a runtime
-  engine in production/package behavior.
-- It preserves the cleanest boundary between:
-  current TypeORM legacy JWT persistence, and
-  future Better Auth persistence concerns.
-- It keeps the future go/no-go decision in `#123` focused on product fit, not
-  on whether Anarchitects is willing to own a long-term custom adapter.
-
-## Fallback Path
-
-Keep **Option B: custom Better Auth TypeORM adapter** as the explicit fallback.
-
-Reconsider the custom adapter path only if one or more of these become true:
-
-- isolated Better Auth persistence creates unacceptable operational complexity
-  for host applications,
-- the migration path requires strong TypeORM-native control that Better Auth’s
-  intended persistence model does not provide cleanly,
-- or a single-ORM operational model is judged more important than minimizing
-  framework-specific maintenance ownership.
-
-If that fallback is chosen later:
-
-- implement it first as an internal adapter in this repo,
-- require proof that current entities can be reused safely or document which new
-  Better Auth-specific entities are still required,
-- and treat extraction to a separate Anarchitects community adapter/plugin repo
-  as a later packaging decision, not part of `#121`.
+- The current `AuthEnginePort` seam remains the runtime boundary.
+- Follow-on work should introduce a dedicated application-layer persistence port
+  for Better Auth persistence strategy selection so controllers and public
+  contracts do not branch on persistence type.
 
 ## Consequences For Follow-On Work
 
-- `#123` should treat isolated Better Auth-owned persistence as the default
-  recommendation when finalizing the go/no-go ADR.
+- `#123` should finalize ADR 106 with `Conditional GO` and with this dual-path
+  persistence strategy as accepted direction.
+- Any future implementation issue should add configuration for:
+  - Better Auth persistence mode selection
+  - isolated topology selection
 - Any future implementation issue should add Better Auth migrations/schema as an
   internal persistence concern separate from the current legacy JWT TypeORM
   entities.
-- If the custom TypeORM adapter path is ever selected, it should be scoped as a
-  distinct implementation stream with explicit ownership and maintenance costs,
-  not folded into generic Better Auth adoption work.
+- The internal TypeORM adapter should be implemented in this repo first and
+  developed in parallel with the community-repo incubation work.


### PR DESCRIPTION
Finalize the Better Auth decision record and persistence ADRs for the auth domain.

- update ADR 106 to record Conditional GO as the final outcome
- revise ADR 106 to capture the accepted configuration-driven Better Auth persistence model behind the application-layer boundary
- update ADR 121 from a proposed recommendation to the accepted dual-path persistence strategy
- record isolated Better Auth-owned persistence as the default Better Auth mode with the Anarchitects TypeORM adapter supported in parallel
- keep public auth contracts framework-agnostic and Better Auth internals confined to auth-nest

Closes #106 Closes #121 Closes #123