### PR TITLE
feat(auth-nest): add neutral engine persistence config

### DIFF
--- a/libs/auth/nest/README.md
+++ b/libs/auth/nest/README.md
@@ -34,30 +34,32 @@ The internal `@anarchitects/auth-ts` and `@anarchitects/common-nest-mailer` pack
 
 ## Exports
 
-| Import path                                          | Contents                                                                                                                                         |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `@anarchitects/auth-nest`                            | `AuthModule.forRoot(...)`, `AuthModule.forRootFromConfig(...)`, plus re-exports of layered entry points for convenience                          |
+| Import path                                          | Contents                                                                                                                                                                               |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@anarchitects/auth-nest`                            | `AuthModule.forRoot(...)`, `AuthModule.forRootFromConfig(...)`, plus re-exports of layered entry points for convenience                                                                |
 | `@anarchitects/auth-nest/application`                | `AuthApplicationModule`, `AuthService`, `JwtAuthService`, `HashService`, `BcryptHashService`, `PoliciesService`, `AbilityFactory`, `JwtStrategy`, resource-authorization helpers/types |
-| `@anarchitects/auth-nest/presentation`               | `AuthPresentationModule`, `AuthController`, `PoliciesGuard`, `ResourceAuthorizationGuard`, `@Policies()`, `@AuthorizeResource()`, `@AuthorizedResource()`, `RoutePolicy` |
-| `@anarchitects/auth-nest/infrastructure-persistence` | `AuthPersistenceModule`, `AuthUserRepository`, `TypeormAuthUserRepository`, migration                                                            |
-| `@anarchitects/auth-nest/infrastructure-mailer`      | `AuthMailerModule`, `NodeMailerAdapter`                                                                                                          |
-| `@anarchitects/auth-nest/config`                     | `authConfig`, `AuthConfig` type, `InjectAuthConfig()`                                                                                            |
+| `@anarchitects/auth-nest/presentation`               | `AuthPresentationModule`, `AuthController`, `PoliciesGuard`, `ResourceAuthorizationGuard`, `@Policies()`, `@AuthorizeResource()`, `@AuthorizedResource()`, `RoutePolicy`               |
+| `@anarchitects/auth-nest/infrastructure-persistence` | `AuthPersistenceModule`, `AuthUserRepository`, `TypeormAuthUserRepository`, migration                                                                                                  |
+| `@anarchitects/auth-nest/infrastructure-mailer`      | `AuthMailerModule`, `NodeMailerAdapter`                                                                                                                                                |
+| `@anarchitects/auth-nest/config`                     | `authConfig`, `AuthConfig` type, `InjectAuthConfig()`                                                                                                                                  |
 
 ## Configuration
 
 The library reads configuration through `@nestjs/config` using a namespaced `authConfig` registered under the key `auth`. Set the following environment variables to customise behaviour:
 
-| Variable                    | Description                                                                          | Default                  |
-| --------------------------- | ------------------------------------------------------------------------------------ | ------------------------ |
-| `AUTH_JWT_SECRET`           | Secret key used to sign and verify JWTs. **Must** be overridden in production.       | `default_jwt_secret`     |
-| `AUTH_JWT_EXPIRATION`       | Token lifetime (e.g. `3600s`, `15m`, `1d`).                                          | `3600s`                  |
-| `AUTH_JWT_AUDIENCE`         | Expected `aud` claim in the JWT.                                                     | `your_audience`          |
-| `AUTH_JWT_ISSUER`           | Expected `iss` claim in the JWT.                                                     | `your_issuer`            |
-| `AUTH_ENCRYPTION_ALGORITHM` | Password hashing algorithm (`bcrypt`).                                               | `bcrypt`                 |
-| `AUTH_ENCRYPTION_KEY`       | Symmetric key for additional encryption needs. **Must** be overridden in production. | `default_encryption_key` |
-| `AUTH_PERSISTENCE`          | Persistence adapter key used by `forRootFromConfig(...)`.                            | `typeorm`                |
-| `AUTH_MAILER_PROVIDER`      | Domain mailer provider for `forRootFromConfig(...)` (`node` or `noop`).              | `node`                   |
-| `AUTH_STRATEGIES`           | Comma-separated auth strategies for config-driven module composition.                | `jwt`                    |
+| Variable                        | Description                                                                          | Default                  |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ------------------------ |
+| `AUTH_JWT_SECRET`               | Secret key used to sign and verify JWTs. **Must** be overridden in production.       | `default_jwt_secret`     |
+| `AUTH_JWT_EXPIRATION`           | Token lifetime (e.g. `3600s`, `15m`, `1d`).                                          | `3600s`                  |
+| `AUTH_JWT_AUDIENCE`             | Expected `aud` claim in the JWT.                                                     | `your_audience`          |
+| `AUTH_JWT_ISSUER`               | Expected `iss` claim in the JWT.                                                     | `your_issuer`            |
+| `AUTH_ENCRYPTION_ALGORITHM`     | Password hashing algorithm (`bcrypt`).                                               | `bcrypt`                 |
+| `AUTH_ENCRYPTION_KEY`           | Symmetric key for additional encryption needs. **Must** be overridden in production. | `default_encryption_key` |
+| `AUTH_PERSISTENCE`              | Legacy auth persistence adapter key used by `forRootFromConfig(...)`.                | `typeorm`                |
+| `AUTH_ENGINE_PERSISTENCE_MODE`  | Engine-side persistence mode used when `AUTH_ENGINE=better-auth`.                    | `isolated`               |
+| `AUTH_ENGINE_ISOLATED_TOPOLOGY` | Isolated engine topology used when engine persistence mode is `isolated`.            | `same-db`                |
+| `AUTH_MAILER_PROVIDER`          | Domain mailer provider for `forRootFromConfig(...)` (`node` or `noop`).              | `node`                   |
+| `AUTH_STRATEGIES`               | Comma-separated auth strategies for config-driven module composition.                | `jwt`                    |
 
 > **Security note:** The defaults for `AUTH_JWT_SECRET` and `AUTH_ENCRYPTION_KEY` are intentionally insecure placeholders. Always provide strong, unique values in any deployed environment.
 

--- a/libs/auth/nest/src/application/application.module.spec.ts
+++ b/libs/auth/nest/src/application/application.module.spec.ts
@@ -10,6 +10,11 @@ import { JwtAuthService } from './services/jwt-auth.service';
 
 const ORIGINAL_AUTH_PERSISTENCE = process.env['AUTH_PERSISTENCE'];
 const ORIGINAL_AUTH_STRATEGIES = process.env['AUTH_STRATEGIES'];
+const ORIGINAL_AUTH_ENGINE = process.env['AUTH_ENGINE'];
+const ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE =
+  process.env['AUTH_ENGINE_PERSISTENCE_MODE'];
+const ORIGINAL_AUTH_ENGINE_ISOLATED_TOPOLOGY =
+  process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'];
 
 describe('AuthApplicationModule', () => {
   afterEach(() => {
@@ -23,6 +28,26 @@ describe('AuthApplicationModule', () => {
       delete process.env['AUTH_STRATEGIES'];
     } else {
       process.env['AUTH_STRATEGIES'] = ORIGINAL_AUTH_STRATEGIES;
+    }
+
+    if (ORIGINAL_AUTH_ENGINE === undefined) {
+      delete process.env['AUTH_ENGINE'];
+    } else {
+      process.env['AUTH_ENGINE'] = ORIGINAL_AUTH_ENGINE;
+    }
+
+    if (ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE === undefined) {
+      delete process.env['AUTH_ENGINE_PERSISTENCE_MODE'];
+    } else {
+      process.env['AUTH_ENGINE_PERSISTENCE_MODE'] =
+        ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE;
+    }
+
+    if (ORIGINAL_AUTH_ENGINE_ISOLATED_TOPOLOGY === undefined) {
+      delete process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'];
+    } else {
+      process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'] =
+        ORIGINAL_AUTH_ENGINE_ISOLATED_TOPOLOGY;
     }
   });
 
@@ -81,6 +106,20 @@ describe('AuthApplicationModule', () => {
     });
 
     expect(moduleMetadata.module).toBe(AuthApplicationModule);
+  });
+
+  it('should accept neutral engine persistence env settings without changing composition', () => {
+    process.env['AUTH_ENGINE'] = 'better-auth';
+    process.env['AUTH_ENGINE_PERSISTENCE_MODE'] = 'typeorm-adapter';
+    process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'] = 'separate-db';
+
+    const moduleMetadata = AuthApplicationModule.forRootFromConfig({
+      authStrategies: ['jwt'],
+      persistence: { persistence: 'typeorm' },
+    });
+
+    expect(moduleMetadata.module).toBe(AuthApplicationModule);
+    expect(moduleMetadata.exports).toContain(AuthService);
   });
 
   it('should keep forRoot explicit and ignore AUTH_STRATEGIES', () => {

--- a/libs/auth/nest/src/application/application.module.ts
+++ b/libs/auth/nest/src/application/application.module.ts
@@ -130,6 +130,14 @@ export class AuthApplicationModule extends ConfigurableModuleClass {
         ...configOptions.encryption,
         ...overrides.encryption,
       },
+      engineOptions: {
+        ...configOptions.engineOptions,
+        ...overrides.engineOptions,
+        persistence: {
+          ...configOptions.engineOptions?.persistence,
+          ...overrides.engineOptions?.persistence,
+        },
+      },
       persistence: {
         ...configOptions.persistence,
         ...overrides.persistence,

--- a/libs/auth/nest/src/auth.module.ts
+++ b/libs/auth/nest/src/auth.module.ts
@@ -36,6 +36,16 @@ export class AuthModule {
             ...configOptions.presentation?.application?.encryption,
             ...overrides.presentation?.application?.encryption,
           },
+          engineOptions: {
+            ...configOptions.presentation?.application?.engineOptions,
+            ...overrides.presentation?.application?.engineOptions,
+            persistence: {
+              ...configOptions.presentation?.application?.engineOptions
+                ?.persistence,
+              ...overrides.presentation?.application?.engineOptions
+                ?.persistence,
+            },
+          },
           persistence: {
             ...configOptions.presentation?.application?.persistence,
             ...overrides.presentation?.application?.persistence,

--- a/libs/auth/nest/src/config/auth.config.spec.ts
+++ b/libs/auth/nest/src/config/auth.config.spec.ts
@@ -12,6 +12,8 @@ const AUTH_ENV_KEYS = [
   'AUTH_STRATEGIES',
   'AUTH_ENGINE',
   'AUTH_SESSION_MODE',
+  'AUTH_ENGINE_PERSISTENCE_MODE',
+  'AUTH_ENGINE_ISOLATED_TOPOLOGY',
   'AUTH_FEATURE_PASSKEYS',
   'AUTH_FEATURE_SOCIAL',
   'AUTH_FEATURE_OIDC',
@@ -67,6 +69,12 @@ describe('authConfig', () => {
       authStrategies: ['jwt'],
       engine: 'legacy-jwt',
       sessionMode: 'jwt',
+      engineOptions: {
+        persistence: {
+          mode: 'isolated',
+          isolatedTopology: 'same-db',
+        },
+      },
       features: {
         passkeys: false,
         social: false,
@@ -103,6 +111,8 @@ describe('authConfig', () => {
     process.env['AUTH_STRATEGIES'] = 'jwt, custom';
     process.env['AUTH_ENGINE'] = 'better-auth';
     process.env['AUTH_SESSION_MODE'] = 'session';
+    process.env['AUTH_ENGINE_PERSISTENCE_MODE'] = 'typeorm-adapter';
+    process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'] = 'separate-db';
     process.env['AUTH_FEATURE_PASSKEYS'] = 'true';
     process.env['AUTH_FEATURE_SOCIAL'] = 'true';
     process.env['AUTH_FEATURE_OIDC'] = 'false';
@@ -127,6 +137,12 @@ describe('authConfig', () => {
       authStrategies: ['jwt', 'custom'],
       engine: 'better-auth',
       sessionMode: 'session',
+      engineOptions: {
+        persistence: {
+          mode: 'typeorm-adapter',
+          isolatedTopology: 'separate-db',
+        },
+      },
       features: {
         passkeys: true,
         social: true,
@@ -161,6 +177,22 @@ describe('authConfig', () => {
     process.env['AUTH_ENGINE'] = 'invalid';
 
     expect(() => authConfig()).toThrow('Unsupported auth engine: invalid');
+  });
+
+  it('throws when AUTH_ENGINE_PERSISTENCE_MODE is unsupported', () => {
+    process.env['AUTH_ENGINE_PERSISTENCE_MODE'] = 'invalid';
+
+    expect(() => authConfig()).toThrow(
+      'Unsupported auth engine persistence mode: invalid',
+    );
+  });
+
+  it('throws when AUTH_ENGINE_ISOLATED_TOPOLOGY is unsupported', () => {
+    process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'] = 'invalid';
+
+    expect(() => authConfig()).toThrow(
+      'Unsupported auth engine isolated topology: invalid',
+    );
   });
 
   it('falls back to default strategies when AUTH_STRATEGIES is empty', () => {

--- a/libs/auth/nest/src/config/auth.config.ts
+++ b/libs/auth/nest/src/config/auth.config.ts
@@ -14,6 +14,8 @@ export const DEFAULT_AUTH_MAILER_PROVIDER = 'node';
 export const DEFAULT_AUTH_STRATEGIES = ['jwt'] as const;
 export const DEFAULT_AUTH_ENGINE = 'legacy-jwt';
 export const DEFAULT_AUTH_SESSION_MODE = 'jwt';
+export const DEFAULT_AUTH_ENGINE_PERSISTENCE_MODE = 'isolated';
+export const DEFAULT_AUTH_ENGINE_ISOLATED_TOPOLOGY = 'same-db';
 
 const parseBoolean = (value: string | undefined, fallback = false): boolean => {
   if (value === undefined) {
@@ -95,6 +97,36 @@ const parseSessionMode = (): 'jwt' | 'session' => {
   }
 };
 
+const parseAuthEnginePersistenceMode = (): 'isolated' | 'typeorm-adapter' => {
+  const value = process.env['AUTH_ENGINE_PERSISTENCE_MODE'];
+  if (value === undefined) {
+    return DEFAULT_AUTH_ENGINE_PERSISTENCE_MODE;
+  }
+
+  switch (value) {
+    case 'isolated':
+    case 'typeorm-adapter':
+      return value;
+    default:
+      throw new Error(`Unsupported auth engine persistence mode: ${value}`);
+  }
+};
+
+const parseAuthEngineIsolatedTopology = (): 'same-db' | 'separate-db' => {
+  const value = process.env['AUTH_ENGINE_ISOLATED_TOPOLOGY'];
+  if (value === undefined) {
+    return DEFAULT_AUTH_ENGINE_ISOLATED_TOPOLOGY;
+  }
+
+  switch (value) {
+    case 'same-db':
+    case 'separate-db':
+      return value;
+    default:
+      throw new Error(`Unsupported auth engine isolated topology: ${value}`);
+  }
+};
+
 export const authConfig = registerAs(AUTH_CONFIG_KEY, () => ({
   jwtSecret: process.env['AUTH_JWT_SECRET'] ?? DEFAULT_AUTH_JWT_SECRET,
   jwtExpiration:
@@ -111,6 +143,12 @@ export const authConfig = registerAs(AUTH_CONFIG_KEY, () => ({
   authStrategies: parseAuthStrategies(),
   engine: parseAuthEngine(),
   sessionMode: parseSessionMode(),
+  engineOptions: {
+    persistence: {
+      mode: parseAuthEnginePersistenceMode(),
+      isolatedTopology: parseAuthEngineIsolatedTopology(),
+    },
+  },
   features: {
     passkeys: parseBoolean(process.env['AUTH_FEATURE_PASSKEYS']),
     social: parseBoolean(process.env['AUTH_FEATURE_SOCIAL']),

--- a/libs/auth/nest/src/config/module-options.spec.ts
+++ b/libs/auth/nest/src/config/module-options.spec.ts
@@ -22,6 +22,12 @@ describe('auth module option mappers', () => {
     authStrategies: ['jwt'],
     engine: 'better-auth',
     sessionMode: 'session',
+    engineOptions: {
+      persistence: {
+        mode: 'typeorm-adapter',
+        isolatedTopology: 'separate-db',
+      },
+    },
     features: {
       passkeys: true,
       social: true,
@@ -62,6 +68,12 @@ describe('auth module option mappers', () => {
       authStrategies: ['jwt'],
       engine: 'better-auth',
       sessionMode: 'session',
+      engineOptions: {
+        persistence: {
+          mode: 'typeorm-adapter',
+          isolatedTopology: 'separate-db',
+        },
+      },
       features: {
         passkeys: true,
         social: true,
@@ -97,6 +109,12 @@ describe('auth module option mappers', () => {
         authStrategies: ['jwt'],
         engine: 'better-auth',
         sessionMode: 'session',
+        engineOptions: {
+          persistence: {
+            mode: 'typeorm-adapter',
+            isolatedTopology: 'separate-db',
+          },
+        },
         features: {
           passkeys: true,
           social: true,
@@ -134,6 +152,12 @@ describe('auth module option mappers', () => {
           authStrategies: ['jwt'],
           engine: 'better-auth',
           sessionMode: 'session',
+          engineOptions: {
+            persistence: {
+              mode: 'typeorm-adapter',
+              isolatedTopology: 'separate-db',
+            },
+          },
           features: {
             passkeys: true,
             social: true,
@@ -175,6 +199,12 @@ describe('auth module option resolvers', () => {
       authStrategies: ['jwt'],
       engine: 'legacy-jwt',
       sessionMode: 'jwt',
+      engineOptions: {
+        persistence: {
+          mode: 'isolated',
+          isolatedTopology: 'same-db',
+        },
+      },
       features: {
         passkeys: false,
         social: false,
@@ -209,6 +239,12 @@ describe('auth module option resolvers', () => {
           authStrategies: ['jwt'],
           engine: 'legacy-jwt',
           sessionMode: 'jwt',
+          engineOptions: {
+            persistence: {
+              mode: 'isolated',
+              isolatedTopology: 'same-db',
+            },
+          },
           features: {
             passkeys: false,
             social: false,
@@ -254,6 +290,12 @@ describe('auth module option resolvers', () => {
       authStrategies: ['jwt'],
       engine: 'legacy-jwt',
       sessionMode: 'jwt',
+      engineOptions: {
+        persistence: {
+          mode: 'isolated',
+          isolatedTopology: 'same-db',
+        },
+      },
       features: {
         passkeys: false,
         social: false,
@@ -279,5 +321,27 @@ describe('auth module option resolvers', () => {
       persistence: { persistence: 'typeorm' },
       resourceAuthorization: { loaders },
     });
+  });
+
+  it('lets explicit engine persistence overrides win over defaults', () => {
+    expect(
+      resolveAuthApplicationModuleOptions({
+        engineOptions: {
+          persistence: {
+            mode: 'typeorm-adapter',
+            isolatedTopology: 'separate-db',
+          },
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        engineOptions: {
+          persistence: {
+            mode: 'typeorm-adapter',
+            isolatedTopology: 'separate-db',
+          },
+        },
+      }),
+    );
   });
 });

--- a/libs/auth/nest/src/config/module-options.ts
+++ b/libs/auth/nest/src/config/module-options.ts
@@ -1,6 +1,8 @@
 import {
   DEFAULT_AUTH_ENCRYPTION_ALGORITHM,
   DEFAULT_AUTH_ENCRYPTION_KEY,
+  DEFAULT_AUTH_ENGINE_ISOLATED_TOPOLOGY,
+  DEFAULT_AUTH_ENGINE_PERSISTENCE_MODE,
   DEFAULT_AUTH_MAILER_PROVIDER,
   DEFAULT_AUTH_PERSISTENCE,
   DEFAULT_AUTH_STRATEGIES,
@@ -11,6 +13,18 @@ import type { ResourceAuthorizationOptions } from '../application/resource-autho
 
 export type AuthEngine = 'legacy-jwt' | 'better-auth';
 export type AuthSessionMode = 'jwt' | 'session';
+export type AuthEnginePersistenceMode = 'isolated' | 'typeorm-adapter';
+export type AuthEngineIsolatedTopology = 'same-db' | 'separate-db';
+
+export type AuthEnginePersistenceOptions = {
+  mode?: AuthEnginePersistenceMode;
+  isolatedTopology?: AuthEngineIsolatedTopology;
+};
+
+export type ResolvedAuthEnginePersistenceOptions = {
+  mode: AuthEnginePersistenceMode;
+  isolatedTopology: AuthEngineIsolatedTopology;
+};
 
 export type AuthSpikeSocialProviderConfig = {
   clientId?: string;
@@ -65,6 +79,9 @@ export type AuthApplicationModuleOptions = {
   authStrategies?: string[];
   engine?: AuthEngine;
   sessionMode?: AuthSessionMode;
+  engineOptions?: {
+    persistence?: AuthEnginePersistenceOptions;
+  };
   features?: {
     passkeys?: boolean;
     social?: boolean;
@@ -83,6 +100,9 @@ export type ResolvedAuthApplicationModuleOptions = {
   authStrategies: string[];
   engine: AuthEngine;
   sessionMode: AuthSessionMode;
+  engineOptions: {
+    persistence: ResolvedAuthEnginePersistenceOptions;
+  };
   features: {
     passkeys: boolean;
     social: boolean;
@@ -131,12 +151,25 @@ export const resolveAuthMailerModuleOptions = (
   provider: options.provider ?? DEFAULT_AUTH_MAILER_PROVIDER,
 });
 
+export const resolveAuthEnginePersistenceOptions = (
+  options: AuthEnginePersistenceOptions = {},
+): ResolvedAuthEnginePersistenceOptions => ({
+  mode: options.mode ?? DEFAULT_AUTH_ENGINE_PERSISTENCE_MODE,
+  isolatedTopology:
+    options.isolatedTopology ?? DEFAULT_AUTH_ENGINE_ISOLATED_TOPOLOGY,
+});
+
 export const resolveAuthApplicationModuleOptions = (
   options: AuthApplicationModuleOptions = {},
 ): ResolvedAuthApplicationModuleOptions => ({
   authStrategies: options.authStrategies ?? [...DEFAULT_AUTH_STRATEGIES],
   engine: options.engine ?? 'legacy-jwt',
   sessionMode: options.sessionMode ?? 'jwt',
+  engineOptions: {
+    persistence: resolveAuthEnginePersistenceOptions(
+      options.engineOptions?.persistence,
+    ),
+  },
   features: {
     passkeys: options.features?.passkeys ?? false,
     social: options.features?.social ?? false,
@@ -204,6 +237,16 @@ export const mapAuthConfigToApplicationModuleOptions = (
   authStrategies: config.authStrategies ?? [...DEFAULT_AUTH_STRATEGIES],
   engine: config.engine ?? 'legacy-jwt',
   sessionMode: config.sessionMode ?? 'jwt',
+  engineOptions: {
+    persistence: {
+      mode:
+        config.engineOptions?.persistence?.mode ??
+        DEFAULT_AUTH_ENGINE_PERSISTENCE_MODE,
+      isolatedTopology:
+        config.engineOptions?.persistence?.isolatedTopology ??
+        DEFAULT_AUTH_ENGINE_ISOLATED_TOPOLOGY,
+    },
+  },
   features: {
     passkeys: config.features?.passkeys ?? false,
     social: config.features?.social ?? false,

--- a/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-spike.harness.spec.ts
+++ b/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-spike.harness.spec.ts
@@ -33,6 +33,12 @@ describe('BetterAuthSpikeHarness', () => {
       authStrategies: ['jwt'],
       engine: 'better-auth',
       sessionMode: 'session',
+      engineOptions: {
+        persistence: {
+          mode: 'isolated',
+          isolatedTopology: 'same-db',
+        },
+      },
       features: {
         passkeys: true,
         social: true,

--- a/libs/auth/nest/src/presentation/presentation.module.spec.ts
+++ b/libs/auth/nest/src/presentation/presentation.module.spec.ts
@@ -3,15 +3,23 @@ import { AuthApplicationModule } from '../application';
 import { AuthPresentationModule } from './presentation.module';
 
 const ORIGINAL_AUTH_PERSISTENCE = process.env['AUTH_PERSISTENCE'];
+const ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE =
+  process.env['AUTH_ENGINE_PERSISTENCE_MODE'];
 
 describe('AuthPresentationModule', () => {
   afterEach(() => {
     if (ORIGINAL_AUTH_PERSISTENCE === undefined) {
       delete process.env['AUTH_PERSISTENCE'];
-      return;
+    } else {
+      process.env['AUTH_PERSISTENCE'] = ORIGINAL_AUTH_PERSISTENCE;
     }
 
-    process.env['AUTH_PERSISTENCE'] = ORIGINAL_AUTH_PERSISTENCE;
+    if (ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE === undefined) {
+      delete process.env['AUTH_ENGINE_PERSISTENCE_MODE'];
+    } else {
+      process.env['AUTH_ENGINE_PERSISTENCE_MODE'] =
+        ORIGINAL_AUTH_ENGINE_PERSISTENCE_MODE;
+    }
   });
 
   it('should compose application forRoot options when overrides are provided', () => {
@@ -37,5 +45,17 @@ describe('AuthPresentationModule', () => {
     expect(() => AuthPresentationModule.forRootFromConfig()).toThrow(
       'Unsupported persistence type: unsupported',
     );
+  });
+
+  it('should allow neutral engine persistence settings through forRootFromConfig', () => {
+    process.env['AUTH_ENGINE_PERSISTENCE_MODE'] = 'isolated';
+
+    const moduleMetadata = AuthPresentationModule.forRootFromConfig({
+      application: {
+        persistence: { persistence: 'typeorm' },
+      },
+    });
+
+    expect(moduleMetadata.module).toBe(AuthPresentationModule);
   });
 });

--- a/libs/auth/nest/src/presentation/presentation.module.ts
+++ b/libs/auth/nest/src/presentation/presentation.module.ts
@@ -39,6 +39,14 @@ export class AuthPresentationModule {
           ...configOptions.application?.encryption,
           ...overrides.application?.encryption,
         },
+        engineOptions: {
+          ...configOptions.application?.engineOptions,
+          ...overrides.application?.engineOptions,
+          persistence: {
+            ...configOptions.application?.engineOptions?.persistence,
+            ...overrides.application?.engineOptions?.persistence,
+          },
+        },
         persistence: {
           ...configOptions.application?.persistence,
           ...overrides.application?.persistence,


### PR DESCRIPTION
Refs #163 Closes #165

- add neutral engine persistence env vars and defaults
- thread engineOptions.persistence through config/module option resolution
- update docs and test coverage without changing runtime composition