### PR TITLE
Refs #163

### DIFF
--- a/libs/auth/nest/src/application/application.module.spec.ts
+++ b/libs/auth/nest/src/application/application.module.spec.ts
@@ -3,10 +3,13 @@ import { AuthApplicationModule } from './application.module';
 import { LegacyJwtAuthEngineAdapter } from '../infrastructure-engine/legacy-jwt-auth-engine.adapter';
 import { AUTH_RESOURCE_AUTHORIZATION_LOADERS } from './resource-authorization.tokens';
 import { AuthEnginePort } from './services/auth-engine.port';
+import { AuthEnginePersistencePort } from './services/auth-engine-persistence.port';
 import { AuthOrchestrationService } from './services/auth-orchestration.service';
 import { AuthPersistenceModule } from '../infrastructure-persistence';
 import { AuthService } from './services/auth.service';
 import { JwtAuthService } from './services/jwt-auth.service';
+import { BetterAuthIsolatedPersistenceAdapter } from '../infrastructure-engine/better-auth/better-auth-isolated-persistence.adapter';
+import { BetterAuthTypeormAdapterPersistenceAdapter } from '../infrastructure-engine/better-auth/better-auth-typeorm-adapter-persistence.adapter';
 
 const ORIGINAL_AUTH_PERSISTENCE = process.env['AUTH_PERSISTENCE'];
 const ORIGINAL_AUTH_STRATEGIES = process.env['AUTH_STRATEGIES'];
@@ -122,6 +125,58 @@ describe('AuthApplicationModule', () => {
     expect(moduleMetadata.exports).toContain(AuthService);
   });
 
+  it('should select the isolated Better Auth persistence provider when configured', () => {
+    const moduleMetadata = AuthApplicationModule.forRoot({
+      engine: 'better-auth',
+      engineOptions: {
+        persistence: {
+          mode: 'isolated',
+          isolatedTopology: 'same-db',
+        },
+      },
+      authStrategies: ['jwt'],
+      spike: {
+        proofHarnessEnabled: true,
+      },
+    });
+
+    expect(moduleMetadata.providers).toEqual(
+      expect.arrayContaining([
+        BetterAuthIsolatedPersistenceAdapter,
+        expect.objectContaining({
+          provide: AuthEnginePersistencePort,
+          useExisting: BetterAuthIsolatedPersistenceAdapter,
+        }),
+      ]),
+    );
+  });
+
+  it('should select the TypeORM-adapter Better Auth persistence provider when configured', () => {
+    const moduleMetadata = AuthApplicationModule.forRoot({
+      engine: 'better-auth',
+      engineOptions: {
+        persistence: {
+          mode: 'typeorm-adapter',
+          isolatedTopology: 'separate-db',
+        },
+      },
+      authStrategies: ['jwt'],
+      spike: {
+        proofHarnessEnabled: true,
+      },
+    });
+
+    expect(moduleMetadata.providers).toEqual(
+      expect.arrayContaining([
+        BetterAuthTypeormAdapterPersistenceAdapter,
+        expect.objectContaining({
+          provide: AuthEnginePersistencePort,
+          useExisting: BetterAuthTypeormAdapterPersistenceAdapter,
+        }),
+      ]),
+    );
+  });
+
   it('should keep forRoot explicit and ignore AUTH_STRATEGIES', () => {
     process.env['AUTH_STRATEGIES'] = 'custom';
     const moduleMetadata = AuthApplicationModule.forRoot({
@@ -159,6 +214,13 @@ describe('AuthApplicationModule', () => {
         expect.objectContaining({
           provide: JwtAuthService,
           useExisting: AuthOrchestrationService,
+        }),
+      ]),
+    );
+    expect(moduleMetadata.providers).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provide: AuthEnginePersistencePort,
         }),
       ]),
     );

--- a/libs/auth/nest/src/application/application.module.ts
+++ b/libs/auth/nest/src/application/application.module.ts
@@ -9,6 +9,8 @@ import {
   resolveAuthApplicationModuleOptions,
 } from '../config';
 import { BetterAuthAuthEngineAdapter } from '../infrastructure-engine/better-auth/better-auth-auth-engine.adapter';
+import { BetterAuthIsolatedPersistenceAdapter } from '../infrastructure-engine/better-auth/better-auth-isolated-persistence.adapter';
+import { BetterAuthTypeormAdapterPersistenceAdapter } from '../infrastructure-engine/better-auth/better-auth-typeorm-adapter-persistence.adapter';
 import { LegacyJwtAuthEngineAdapter } from '../infrastructure-engine/legacy-jwt-auth-engine.adapter';
 import { AuthPersistenceModule } from '../infrastructure-persistence';
 import {
@@ -18,6 +20,7 @@ import {
 import { AbilityFactory } from './factories/ability.factory';
 import { AUTH_RESOURCE_AUTHORIZATION_LOADERS } from './resource-authorization.tokens';
 import { AuthEnginePort } from './services/auth-engine.port';
+import { AuthEnginePersistencePort } from './services/auth-engine-persistence.port';
 import { AuthOrchestrationService } from './services/auth-orchestration.service';
 import { AuthService } from './services/auth.service';
 import { BcryptHashService } from './services/bcrypt-hash.service';
@@ -100,10 +103,40 @@ export class AuthApplicationModule extends ConfigurableModuleClass {
     }
 
     if (engine === 'better-auth') {
-      providers.push(BetterAuthAuthEngineAdapter, {
-        provide: AuthEnginePort,
-        useExisting: BetterAuthAuthEngineAdapter,
-      });
+      switch (resolvedOptions.engineOptions.persistence.mode) {
+        case 'isolated':
+          providers.push(
+            BetterAuthIsolatedPersistenceAdapter,
+            {
+              provide: AuthEnginePersistencePort,
+              useExisting: BetterAuthIsolatedPersistenceAdapter,
+            },
+            BetterAuthAuthEngineAdapter,
+            {
+              provide: AuthEnginePort,
+              useExisting: BetterAuthAuthEngineAdapter,
+            },
+          );
+          break;
+        case 'typeorm-adapter':
+          providers.push(
+            BetterAuthTypeormAdapterPersistenceAdapter,
+            {
+              provide: AuthEnginePersistencePort,
+              useExisting: BetterAuthTypeormAdapterPersistenceAdapter,
+            },
+            BetterAuthAuthEngineAdapter,
+            {
+              provide: AuthEnginePort,
+              useExisting: BetterAuthAuthEngineAdapter,
+            },
+          );
+          break;
+        default:
+          throw new Error(
+            `Unsupported auth engine persistence mode: ${resolvedOptions.engineOptions.persistence.mode}`,
+          );
+      }
     } else {
       providers.push(LegacyJwtAuthEngineAdapter, {
         provide: AuthEnginePort,

--- a/libs/auth/nest/src/application/services/auth-engine-persistence.port.ts
+++ b/libs/auth/nest/src/application/services/auth-engine-persistence.port.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export abstract class AuthEnginePersistencePort {
+  abstract resolveDatabase(): Promise<unknown>;
+}

--- a/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-auth-engine.adapter.spec.ts
+++ b/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-auth-engine.adapter.spec.ts
@@ -1,0 +1,131 @@
+import { AuthEnginePersistencePort } from '../../application/services/auth-engine-persistence.port';
+import type { ResolvedAuthApplicationModuleOptions } from '../../config';
+import { BetterAuthAuthEngineAdapter } from './better-auth-auth-engine.adapter';
+import { loadBetterAuthRuntimeModules } from './better-auth.module-loader';
+
+jest.mock('./better-auth.module-loader', () => ({
+  loadBetterAuthRuntimeModules: jest.fn(),
+}));
+
+describe('BetterAuthAuthEngineAdapter', () => {
+  const signInEmail = jest.fn();
+  const betterAuthFactory = jest.fn();
+  const passkey = jest.fn();
+
+  const options = {
+    authStrategies: ['jwt'],
+    engine: 'better-auth',
+    sessionMode: 'session',
+    engineOptions: {
+      persistence: {
+        mode: 'isolated',
+        isolatedTopology: 'same-db',
+      },
+    },
+    features: {
+      passkeys: false,
+      social: false,
+      oidc: false,
+    },
+    spike: {
+      baseUrl: 'http://localhost:3000/api/auth',
+      secret: 'better-auth-spike-secret-32-chars-minimum',
+      proofHarnessEnabled: true,
+      socialProviders: {
+        github: undefined,
+      },
+      passkeys: {
+        rpID: 'localhost',
+        rpName: 'Anarchitecture Auth Spike',
+        origin: undefined,
+      },
+    },
+    encryption: {
+      algorithm: 'bcrypt',
+      key: 'default_encryption_key',
+    },
+    persistence: {
+      persistence: 'typeorm',
+    },
+    resourceAuthorization: {
+      loaders: {},
+    },
+  } satisfies ResolvedAuthApplicationModuleOptions;
+
+  const persistencePort = {
+    resolveDatabase: jest.fn(),
+  } satisfies Pick<AuthEnginePersistencePort, 'resolveDatabase'>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    signInEmail.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+    betterAuthFactory.mockReturnValue({
+      api: {
+        signInEmail,
+      },
+      handler: jest.fn(),
+    });
+    (loadBetterAuthRuntimeModules as jest.Mock).mockResolvedValue({
+      betterAuth: {
+        betterAuth: betterAuthFactory,
+      },
+      betterAuthPasskey: {
+        passkey,
+      },
+    });
+  });
+
+  it('resolves Better Auth persistence through the application-layer port', async () => {
+    const database = { kind: 'database' };
+    persistencePort.resolveDatabase.mockResolvedValue(database);
+
+    const adapter = new BetterAuthAuthEngineAdapter(
+      options,
+      persistencePort as AuthEnginePersistencePort,
+    );
+
+    await expect(
+      adapter.passwordSignIn({
+        credential: 'user@example.com',
+        password: 'password',
+      }),
+    ).resolves.toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+
+    expect(persistencePort.resolveDatabase).toHaveBeenCalled();
+    expect(betterAuthFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database,
+      }),
+    );
+  });
+
+  it('surfaces placeholder persistence selection errors during runtime init', async () => {
+    persistencePort.resolveDatabase.mockRejectedValue(
+      new Error(
+        'Better Auth isolated persistence for topology "same-db" is not implemented yet. See issue #167.',
+      ),
+    );
+
+    const adapter = new BetterAuthAuthEngineAdapter(
+      options,
+      persistencePort as AuthEnginePersistencePort,
+    );
+
+    await expect(
+      adapter.passwordSignIn({
+        credential: 'user@example.com',
+        password: 'password',
+      }),
+    ).rejects.toThrow(
+      'Better Auth isolated persistence for topology "same-db" is not implemented yet. See issue #167.',
+    );
+    expect(betterAuthFactory).not.toHaveBeenCalled();
+  });
+});

--- a/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-auth-engine.adapter.ts
+++ b/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-auth-engine.adapter.ts
@@ -6,6 +6,7 @@ import type {
   RefreshTokenRequestDTO,
 } from '@anarchitects/auth-ts/dtos';
 import { AUTH_APPLICATION_MODULE_OPTIONS } from '../../application/application.module-definition';
+import { AuthEnginePersistencePort } from '../../application/services/auth-engine-persistence.port';
 import type { ResolvedAuthApplicationModuleOptions } from '../../config';
 import {
   AuthEngineCapabilityReport,
@@ -15,7 +16,6 @@ import {
   AuthSocialSignInInput,
 } from '../../application/services/auth-engine.port';
 import { loadBetterAuthRuntimeModules } from './better-auth.module-loader';
-import { importEsmModule } from './dynamic-import';
 
 type BetterAuthApi = {
   signInEmail?: (input: {
@@ -50,6 +50,7 @@ export class BetterAuthAuthEngineAdapter implements AuthEnginePort {
   constructor(
     @Inject(AUTH_APPLICATION_MODULE_OPTIONS)
     private readonly options: ResolvedAuthApplicationModuleOptions,
+    private readonly authEnginePersistencePort: AuthEnginePersistencePort,
   ) {}
 
   async describeCapabilities(): Promise<AuthEngineCapabilityReport> {
@@ -223,14 +224,12 @@ export class BetterAuthAuthEngineAdapter implements AuthEnginePort {
   private async createAuthInstance(): Promise<BetterAuthAuthInstance> {
     const { betterAuth, betterAuthPasskey } =
       await loadBetterAuthRuntimeModules();
-    const { DatabaseSync } = await importEsmModule<{
-      DatabaseSync: new (location: string) => unknown;
-    }>('node:sqlite');
+    const database = await this.authEnginePersistencePort.resolveDatabase();
 
     return betterAuth.betterAuth({
       secret: this.options.spike.secret,
       baseURL: this.options.spike.baseUrl,
-      database: new DatabaseSync(':memory:'),
+      database,
       emailAndPassword: {
         enabled: true,
       },

--- a/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-isolated-persistence.adapter.ts
+++ b/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-isolated-persistence.adapter.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { AUTH_APPLICATION_MODULE_OPTIONS } from '../../application/application.module-definition';
+import { AuthEnginePersistencePort } from '../../application/services/auth-engine-persistence.port';
+import type { ResolvedAuthApplicationModuleOptions } from '../../config';
+
+@Injectable()
+export class BetterAuthIsolatedPersistenceAdapter
+  implements AuthEnginePersistencePort
+{
+  constructor(
+    @Inject(AUTH_APPLICATION_MODULE_OPTIONS)
+    private readonly options: ResolvedAuthApplicationModuleOptions,
+  ) {}
+
+  resolveDatabase(): Promise<unknown> {
+    return Promise.reject(
+      new Error(
+        `Better Auth isolated persistence for topology "${this.options.engineOptions.persistence.isolatedTopology}" is not implemented yet. See issue #167.`,
+      ),
+    );
+  }
+}

--- a/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-typeorm-adapter-persistence.adapter.ts
+++ b/libs/auth/nest/src/infrastructure-engine/better-auth/better-auth-typeorm-adapter-persistence.adapter.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { AuthEnginePersistencePort } from '../../application/services/auth-engine-persistence.port';
+
+@Injectable()
+export class BetterAuthTypeormAdapterPersistenceAdapter
+  implements AuthEnginePersistencePort
+{
+  resolveDatabase(): Promise<unknown> {
+    return Promise.reject(
+      new Error(
+        'Better Auth TypeORM adapter persistence is not implemented yet. See issue #168.',
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #166

- add internal AuthEnginePersistencePort for Better Auth composition
- select isolated or typeorm-adapter placeholder providers in application wiring
- resolve Better Auth database config through the new port and add seam coverage