### PR TITLE
docs(auth): align Better Auth ADRs with current session-first architecture

### DIFF
--- a/docs/adr/106-better-auth-spike.md
+++ b/docs/adr/106-better-auth-spike.md
@@ -2,156 +2,114 @@
 
 ## Status
 
-Accepted - Conditional GO.
+Accepted - Implemented.
 
 ## Context
 
-Issue `#106` asked whether Better Auth can sit behind the existing auth domain
+Issue `#106` asked whether Better Auth could sit behind the existing auth domain
 facades without leaking framework details into:
 
 - `@anarchitects/auth-ts`
 - `@anarchitects/auth-nest`
 - `@anarchitects/auth-angular`
 
-The repo entered this work with:
+The spike started as an evaluation, not as a promise to expose Better Auth
+directly. The success criteria were always:
 
-- a public auth surface that is JWT- and TypeORM-oriented,
-- Nest-owned `/auth/*` routes,
-- TypeORM-backed auth persistence,
-- and no internal seam for evaluating an alternate auth engine.
+- keep package-owned DTOs, models, and routes as the public contract
+- keep Nest route ownership in `auth-nest`
+- keep Angular consumption aligned to package-owned APIs
+- keep Better Auth internal to the auth domain
 
-The goal of the spike was not full migration. The goal was to determine whether
-Better Auth is a viable internal engine candidate behind the existing package
-facades.
+## Final Outcome
 
-## Outcomes Already Achieved
+Better Auth is a viable internal engine behind the auth facades, and the repo
+has since settled on that architecture.
 
-The spike and follow-on sub-issues established the following:
+The implemented product story is now:
 
-### Internal engine seam
+- Better Auth is the only built-in internal auth engine
+- `@anarchitects/auth-nest` remains the public route and integration surface
+- core auth is session-first
+- email/password is always enabled in core auth
+- repo-owned RBAC remains layered on top of Better Auth-backed user/session
+  state
+- JWT, passkeys, social auth, and future authn capabilities are package-owned,
+  plugin-scoped extensions
 
-- Better Auth can be evaluated behind an internal `AuthEnginePort`.
-- The application layer now depends on the internal engine seam rather than
-  binding the entire auth flow directly to the legacy JWT runtime.
-- `legacy-jwt` remains the default engine and active runtime path.
-
-### Public API containment
-
-- Public package APIs remained framework-agnostic during the spike and adapter
-  boundary work.
-- Package-owned Nest controllers remain the canonical public HTTP boundary.
-- Better Auth types, route ownership, and persistence schema were not exposed
-  through public package entry points.
-
-### Packaging/runtime constraints
-
-- Better Auth is ESM-only.
-- `@anarchitects/auth-nest` currently builds as CommonJS.
-- The repo proved that Better Auth can be hosted internally through preserved
-  native dynamic `import()` without forcing a package-format migration during
-  the spike.
-
-### Persistence strategy
-
-- Persistence fit was analyzed separately in [ADR 121](./121-better-auth-persistence-recommendation.md).
-- The accepted model is configuration-driven and abstracted behind an
-  application-layer persistence port.
-- Supported Better Auth persistence modes are:
-  - `isolated`
-  - `typeorm-adapter`
-- The default Better Auth persistence mode is `isolated`.
-- The `isolated` mode supports both:
-  - `same-db`
-  - `separate-db`
-- The default isolated topology is `same-db`.
-
-## Decision Outcome
-
-- Final outcome: `Conditional GO`
-
-Rationale for the final outcome:
-
-- Better Auth appears viable as an internal engine candidate behind
-  `AuthEnginePort`.
-- Public package APIs remained framework-agnostic through the spike and
-  boundary work.
-- The remaining concerns are implementation constraints, not spike failure:
-  configuration-driven persistence composition, session-vs-JWT mapping
-  decisions, and continued public API containment.
-
-## Finalized Conclusions
+## Conclusions That Remain Canonical
 
 ### Route ownership
 
-- Keep package-owned Nest controllers as the canonical public boundary.
-- Do not delegate package public `/auth/*` ownership directly to Better Auth.
-- Any future Better Auth runtime handling should remain wrapped behind the
-  package-owned presentation layer where practical.
+- Keep package-owned Nest controllers as the canonical public HTTP boundary
+- Do not delegate public `/auth/*` ownership directly to raw Better Auth
+  handlers
+- Better Auth runtime handling may sit behind the presentation layer, but it is
+  not the public API
 
 ### Public contract containment
 
-- Better Auth must remain internal to `auth-nest`.
-- Public DTOs, shared models, and Angular-facing APIs must remain
-  framework-agnostic.
-- Better Auth route conventions, session models, and persistence schema must
-  not become public package contract.
+- Better Auth remains internal to `auth-nest`
+- Public DTOs, shared models, and Angular-facing APIs remain package-owned
+- Better Auth types, route conventions, session models, and database concerns
+  must not become public package contract
 
-### Persistence direction
+### Package boundaries
 
-- Better Auth remains internal to `auth-nest`.
-- Better Auth persistence must remain abstracted behind an application-layer
-  port.
-- Persistence mode is configuration-driven.
-- Supported Better Auth persistence modes are:
-  - `isolated`
-  - `typeorm-adapter`
-- Default Better Auth persistence mode: `isolated`.
-- Supported isolated topologies are:
-  - `same-db`
-  - `separate-db`
-- Default isolated topology: `same-db`.
-- The custom TypeORM adapter starts as an internal repo implementation and may
-  later be extracted to an Anarchitects community repo once the contract and
-  maintenance shape are stable.
-- Current TypeORM legacy JWT persistence remains the default and should not be
-  remapped to Better Auth tables by default.
+- `auth-ts` remains the source of truth for package-owned DTOs and models
+- `auth-angular` remains the browser-facing integration surface
+- `auth-nest` owns route composition, orchestration, configuration, and
+  framework integration
 
-## Stop Conditions
+## Persistence Direction
 
-Treat the Better Auth direction as failed if any of the following become true in
-follow-on implementation:
+The current repo no longer treats Better Auth persistence as a public
+mode-selection story.
+
+The settled implementation direction is:
+
+- Better Auth persistence remains internal to `auth-nest`
+- core Better Auth-backed tables are owned by core auth persistence
+- plugin-specific tables, entities, and migrations stay with their plugin
+  modules
+- the application layer depends on internal seams rather than exposing
+  persistence strategy selection as public package API
+
+See [ADR 121](./121-better-auth-persistence-recommendation.md) for the aligned
+persistence decision record.
+
+## Historical Note
+
+The spike phase explored transitional ideas such as alternate engine defaults,
+multiple Better Auth persistence modes, and migration-window coexistence
+strategies.
+
+Those spike-era options are not the current product story anymore.
+
+They should be treated as historical exploration only, not as active
+documentation for the auth domain.
+
+## Stop Conditions That Still Matter
+
+Treat the Better Auth direction as failed if any of the following become true
+in future follow-on work:
 
 - Better Auth types, routes, or persistence concerns leak into public package
-  APIs.
-- Isolated Better Auth persistence cannot remain internal to `auth-nest`.
-- The migration path requires coupling current public/shared models to Better
-  Auth schema.
-- Route delegation prevents stable package docs or contract generation.
-- Session semantics cannot be reconciled with the package surface without
-  destabilizing the public auth contract.
+  APIs
+- package-owned route ownership is lost
+- shared/public DTOs are reshaped around Better Auth internals
+- plugin-specific persistence bleeds back into core auth ownership
+- session-first core auth becomes ambiguous again at the package surface
 
 ## Implementation Implications
 
-If the final outcome is `GO` or `Conditional GO`:
+Follow-on work should preserve the implemented architecture rather than
+reopening the spike.
 
-- Create a separate follow-on implementation parent issue/epic.
-- Create a separate parallel parent issue for Anarchitects community Better
-  Auth integrations.
-- Keep `legacy-jwt` as the default engine until that follow-on implementation
-  lands and is explicitly approved.
-- Treat passkeys, social flows, DTO additions, Better Auth persistence tables,
-  Angular integration, and docs/contract updates as follow-on work.
-- When `engine=better-auth`, default the persistence mode to `isolated`.
-- When `engine=better-auth` and `persistence.mode=isolated`, default the
-  topology to `same-db`.
-- Support the internal TypeORM adapter in parallel as a configuration-driven
-  Better Auth persistence mode, while incubating its extraction path in the
-  community repo track.
+That means:
 
-If the final outcome is `NO-GO`:
-
-- Do not proceed with Better Auth implementation beyond the completed spike and
-  seam work.
-- Keep the repo on the `legacy-jwt` engine path.
-- Treat the completed spike/boundary work as closed evaluation effort rather
-  than migration start.
+- keep Better Auth as the only built-in internal engine
+- keep session-first behavior as the default/core auth story
+- keep plugin authn capabilities explicitly optional and package-scoped
+- keep public documentation and tests aligned to package-owned contracts rather
+  than raw Better Auth behavior

--- a/docs/adr/121-better-auth-persistence-recommendation.md
+++ b/docs/adr/121-better-auth-persistence-recommendation.md
@@ -2,172 +2,90 @@
 
 ## Status
 
-Accepted
+Accepted - Aligned to implemented architecture.
 
 ## Context
 
-Issue `#121` asks for a persistence recommendation for the Better Auth direction
-under umbrella issue `#106`.
+Issue `#121` asked for a persistence recommendation for the Better Auth
+direction under umbrella issue `#106`.
 
-The current repo state is:
+The early evaluation considered multiple migration-era persistence options. The
+repo has since converged on a settled auth architecture, so this ADR now
+records the persistence direction that matches the current implementation rather
+than the earlier exploratory options.
 
-- Legacy auth runtime behavior is implemented through `AuthEnginePort`, with
-  `legacy-jwt` still the default engine.
-- `auth-nest` persistence is TypeORM-backed through `AuthPersistenceModule`,
-  `AuthUserRepository`, `UserEntity`, RBAC entities, and invalidated-token
-  storage.
-- The Better Auth spike intentionally used isolated proof storage and deferred
-  production persistence fit to this issue.
+The current auth product story is:
 
-Relevant current insertion points:
+- Better Auth is the only built-in internal auth engine
+- `auth-nest` remains the public route and integration surface
+- core auth is session-first
+- TypeORM-backed auth persistence remains internal to `auth-nest`
+- core Better Auth tables live in core auth persistence
+- plugin-specific tables and migrations stay with their plugin modules
 
-- [ADR 106](./106-better-auth-spike.md)
-- [`AuthPersistenceModule`](../../libs/auth/nest/src/infrastructure-persistence/persistence.module.ts)
-- [`TypeormAuthUserRepository`](../../libs/auth/nest/src/infrastructure-persistence/repositories/typeorm-auth-user.repository.ts)
+## Accepted Direction
 
-Relevant Better Auth docs:
+Accept a single internal persistence direction for the current repo:
 
-- Better Auth custom adapter guide:
-  https://better-auth.com/docs/guides/create-a-db-adapter
-- Better Auth database concepts:
-  https://better-auth.com/docs/concepts/database
-- Better Auth CLI schema generation:
-  https://better-auth.com/docs/concepts/cli
+- Better Auth-backed persistence remains internal to `auth-nest`
+- TypeORM remains the repo’s persistence control plane
+- the application layer depends on internal seams, not public persistence-mode
+  selectors
+- public package contracts do not expose Better Auth persistence strategy
 
-## Decision Options
+In practice, this means:
 
-### Option A: Isolated Better Auth-Owned Persistence
+- core auth persistence owns:
+  - `users`
+  - `roles`
+  - `permissions`
+  - `user_roles`
+  - `role_permissions`
+  - Better Auth-backed core tables such as `accounts`, `sessions`, and
+    `verifications`
+- plugin-owned persistence stays with plugin modules, for example:
+  - JWT invalidation persistence
+  - passkey persistence
 
-Run Better Auth on its own internal schema/table set and keep the current
-TypeORM auth persistence as the legacy JWT store.
+## Rejected As Current Product Model
 
-Characteristics:
+The following are no longer the active repo story:
 
-- Better Auth owns its own auth, session, account, verification, and plugin
-  storage concerns.
-- Current `UserEntity`, RBAC entities, and invalidated-token storage remain the
-  legacy JWT persistence model.
-- Any future engine coexistence is handled above the persistence layer through
-  `AuthEnginePort`, not by forcing one shared table model.
+- dual public Better Auth persistence modes
+- public persistence-mode selection for consumers
+- isolated-vs-adapter topology selection as documented product behavior
+- treating a migration-window legacy JWT store as the default runtime model
 
-Assessment:
+Those were exploratory evaluation paths, not the settled architecture.
 
-- Implementation complexity: moderate.
-- Migration complexity: moderate, because a second persistence shape must be
-  introduced and operated alongside the current one.
-- Operational fit with current TypeORM usage: acceptable, but it adds a second
-  auth store to reason about.
-- Maintenance burden: lower than a custom adapter because it follows Better
-  Auth’s intended persistence model rather than re-implementing it.
-- Coupling risk: low. This option keeps Better Auth table expectations out of
-  current TypeORM entities and out of `auth-ts`.
-- Public API leakage risk: low, if the store remains internal to `auth-nest`.
+## Non-Negotiable Constraints
 
-Main downside:
+- Better Auth persistence must remain internal to `auth-nest`
+- no public `auth-ts` models should mirror Better Auth tables
+- no public DTO or route contract should become Better Auth-persistence-shaped
+- core auth persistence and plugin persistence ownership must stay separated
+- package-owned route ownership must remain intact even when runtime behavior is
+  Better Auth-backed
 
-- It duplicates auth persistence concerns during the migration window and may
-  require explicit account-linking or synchronization decisions later.
+## Community Packaging Note
 
-### Option B: Custom Better Auth TypeORM Adapter
+Any future community adapter packaging should follow the proven internal
+contract and should not change the product story of this repo.
 
-Build a Better Auth database adapter against TypeORM, first inside this repo,
-and consider later extraction to an Anarchitects community adapters/plugins
-repository only after it proves stable.
+That means:
 
-Characteristics:
-
-- Better Auth would persist through a custom adapter layer owned by Anarchitects.
-- The adapter could reuse some existing TypeORM infrastructure patterns, but it
-  would still need to satisfy Better Auth’s database contract explicitly.
-- Reuse of current entities is not automatic; Better Auth-specific entities
-  would likely still be required unless the current schema happens to match the
-  framework’s persistence expectations closely enough.
-
-Assessment:
-
-- Implementation complexity: high.
-- Migration complexity: high, because the adapter contract, schema ownership,
-  and compatibility surface would all become local responsibilities.
-- Operational fit with current TypeORM usage: strong in the short term because
-  it stays on the repo’s current ORM stack.
-- Maintenance burden: high. This option turns Anarchitects into the maintainer
-  of a Better Auth persistence integration rather than a consumer of one.
-- Coupling risk: medium to high. The pressure to reuse current entities would
-  make it easier to leak Better Auth persistence assumptions into existing auth
-  entities and repositories.
-- Public API leakage risk: medium. A custom adapter increases the chance that
-  framework persistence concepts influence internal package boundaries over time.
-
-Main upside:
-
-- It preserves a single ORM control plane and could reduce operational split if
-  it works cleanly.
-
-Main downside:
-
-- It is a framework-integration product of its own, not just an app-level
-  implementation choice.
-
-## Accepted Strategy
-
-Accept a **dual-path Better Auth persistence strategy** for this repo.
-
-Accepted modes:
-
-- `isolated`: isolated Better Auth-owned persistence
-- `typeorm-adapter`: custom Anarchitects-owned Better Auth TypeORM adapter
-
-Defaults:
-
-- Default Better Auth persistence mode: `isolated`
-- Supported isolated topologies:
-  - `same-db`
-  - `separate-db`
-- Default isolated topology: `same-db`
-
-Reasoning:
-
-- It preserves the architectural goal from `#106`: adopt Better Auth behind the
-  existing facades without forcing framework persistence details into the public
-  package surface.
-- It keeps the cleanest default boundary between current TypeORM legacy JWT
-  persistence and future Better Auth persistence concerns.
-- It still supports a TypeORM-native Better Auth path for hosts or deployments
-  that benefit from a single ORM control plane.
-- It aligns with the repo flexibility paradigm by making persistence strategy
-  application-layer-abstracted and configuration-driven rather than hardwired.
-
-## Delivery Shape
-
-- The TypeORM adapter starts as an internal implementation in this repo.
-- The isolated Better Auth path and the internal TypeORM adapter path are both
-  supported follow-on implementation tracks.
-- The TypeORM adapter is not public package surface in the first implementation
-  phase.
-- In parallel, Anarchitects should start work on a community repo path for the
-  adapter, but community packaging must follow internal contract proof rather
-  than lead it.
-
-## Constraints That Remain Non-Negotiable
-
-- No public `auth-ts` models should be changed to mirror Better Auth tables.
-- No public DTO or route contract should become Better Auth persistence-shaped.
-- Better Auth persistence must remain internal to `auth-nest`.
-- Cross-domain persistence expansion must not be introduced.
-- The current `AuthEnginePort` seam remains the runtime boundary.
-- Follow-on work should introduce a dedicated application-layer persistence port
-  for Better Auth persistence strategy selection so controllers and public
-  contracts do not branch on persistence type.
+- community packaging is secondary to the package-owned auth experience here
+- future extraction must not reintroduce public persistence-mode selection into
+  this repo
+- repo-local docs and tests should continue to describe Better Auth persistence
+  as an internal concern of `auth-nest`
 
 ## Consequences For Follow-On Work
 
-- `#123` should finalize ADR 106 with `Conditional GO` and with this dual-path
-  persistence strategy as accepted direction.
-- Any future implementation issue should add configuration for:
-  - Better Auth persistence mode selection
-  - isolated topology selection
-- Any future implementation issue should add Better Auth migrations/schema as an
-  internal persistence concern separate from the current legacy JWT TypeORM
-  entities.
-- The internal TypeORM adapter should be implemented in this repo first and
-  developed in parallel with the community-repo incubation work.
+Follow-on implementation and docs work should:
+
+- describe Better Auth as the only built-in internal engine
+- describe auth persistence as internal and TypeORM-backed
+- describe core auth as session-first
+- describe plugin persistence as plugin-scoped
+- avoid documenting multiple active persistence strategies for this repo

--- a/docs/guides/auth-migration.md
+++ b/docs/guides/auth-migration.md
@@ -87,6 +87,10 @@ Canonical auth config now lives under:
 
 Canonical environment variable names use the `AUTH_PLUGIN_*` and `AUTH_BETTER_AUTH_*` families.
 
+The current product story does not expose a public engine-selection or
+Better Auth persistence-mode switch. Better Auth and its database integration
+remain internal implementation details of `auth-nest`.
+
 Legacy env aliases may still be tolerated for compatibility in some places, but they are no longer the documented or preferred configuration surface.
 
 ## Import Path Migration

--- a/libs/auth/nest/src/config/auth.config.spec.ts
+++ b/libs/auth/nest/src/config/auth.config.spec.ts
@@ -104,6 +104,13 @@ describe('authConfig', () => {
     });
   });
 
+  it('does not expose public engine or persistence mode selection in the settled config surface', () => {
+    const config = authConfig() as Record<string, unknown>;
+
+    expect(config).not.toHaveProperty('engine');
+    expect(config).not.toHaveProperty('persistence');
+  });
+
   it('maps plugin and Better Auth environment overrides', () => {
     process.env['AUTH_ENCRYPTION_KEY'] = 'enc-key';
     process.env['AUTH_MAILER_PROVIDER'] = 'noop';

--- a/libs/auth/nest/src/config/module-options.spec.ts
+++ b/libs/auth/nest/src/config/module-options.spec.ts
@@ -160,6 +160,18 @@ describe('auth module option resolvers', () => {
     });
   });
 
+  it('keeps Better Auth as the only built-in engine story and does not expose persistence mode selection', () => {
+    const resolved = resolveAuthApplicationModuleOptions({}) as Record<
+      string,
+      unknown
+    >;
+
+    expect(resolved).not.toHaveProperty('engine');
+    expect(resolved).not.toHaveProperty('persistence');
+    expect(resolved).toHaveProperty('betterAuth');
+    expect(resolved).toHaveProperty('plugins');
+  });
+
   it('resolves default root options deterministically', () => {
     expect(resolveAuthModuleOptions({})).toEqual({
       presentation: {


### PR DESCRIPTION
- revise ADR 106 and ADR 121 to match the settled Better Auth auth-nest model
- clarify that engine and persistence mode selection are not public auth config surfaces
- add config tests that lock the Better Auth-only internal engine story