### PR TITLE
feat(common-angular-design): add design root sync contract

### DIFF
--- a/libs/common/angular/design/README.md
+++ b/libs/common/angular/design/README.md
@@ -9,6 +9,7 @@ extensible for consumer applications.
 ## Features
 
 - Typed design-system config providers for theme, density, surface, and layout defaults
+- Explicit root-host directive for syncing theme, density, and surface to DOM attributes
 - Shared semantic token contracts for cross-library visual consistency
 - Base styles and semantic hooks designed for consumer override
 
@@ -46,7 +47,7 @@ Consumers extend at the edges by:
 ### 1) Register context defaults
 
 ```ts
-import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
+import { provideDesignSystemConfig, provideDocumentDesignSystemDomSync } from '@anarchitects/common-angular-design/config';
 
 export const appConfig = {
   providers: [
@@ -57,6 +58,8 @@ export const appConfig = {
       layout: 'list',
       columns: 1,
     }),
+    // Optional fallback when an app cannot annotate its root shell element.
+    ...provideDocumentDesignSystemDomSync(),
   ],
 };
 ```
@@ -69,16 +72,25 @@ import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
 applyAnxBaseStyles();
 ```
 
-### 3) Scope usage with semantic hooks
+### 3) Scope usage with an explicit root host
 
 ```html
-<section class="anx-root" data-anx-theme="default" data-anx-density="comfortable" data-anx-surface="plain" data-anx-layout="list" data-anx-columns="1">
+<section anarchitectsDesignRoot data-anx-layout="list" data-anx-columns="1">
   <div class="anx-region anx-stack">
     <h2 class="anx-heading">Contact</h2>
     <p class="anx-text">A neutral foundation, ready for consumer theming.</p>
   </div>
 </section>
 ```
+
+`anarchitectsDesignRoot` is the canonical setup path. It manages `data-anx-theme`,
+`data-anx-density`, and `data-anx-surface` from the injected design config.
+`data-anx-layout` and `data-anx-columns` remain explicit host attributes in this
+slice.
+
+Existing apps can keep manual `data-anx-theme`, `data-anx-density`, and
+`data-anx-surface` attributes during migration. Explicit manual attributes stay
+authoritative over provider-derived defaults.
 
 ## Usage
 

--- a/libs/common/angular/design/config/README.md
+++ b/libs/common/angular/design/config/README.md
@@ -4,6 +4,8 @@ Typed configuration and provider helpers for the shared Angular design-system co
 
 ## Usage
 
+Canonical setup uses an explicit app-shell host element:
+
 ```ts
 import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
 
@@ -17,3 +19,31 @@ providers: [
   }),
 ];
 ```
+
+```html
+<section anarchitectsDesignRoot data-anx-layout="grid" data-anx-columns="3"></section>
+```
+
+`anarchitectsDesignRoot` manages `theme`, `density`, and `surface` on that
+explicit host.
+`layout` and `columns` remain explicit in v1.
+
+When a host app cannot annotate its shell template, use the document fallback:
+
+```ts
+import { provideDesignSystemConfig, provideDocumentDesignSystemDomSync } from '@anarchitects/common-angular-design/config';
+
+providers: [
+  ...provideDesignSystemConfig({
+    theme: 'acme',
+    density: 'compact',
+    surface: 'card',
+    layout: 'grid',
+    columns: 3,
+  }),
+  ...provideDocumentDesignSystemDomSync(),
+];
+```
+
+Existing manual `data-anx-theme`, `data-anx-density`, and `data-anx-surface`
+attributes remain supported and win over provider-derived defaults.

--- a/libs/common/angular/design/config/src/design-root.contract.spec.ts
+++ b/libs/common/angular/design/config/src/design-root.contract.spec.ts
@@ -1,0 +1,98 @@
+import { ANX_DATA_ATTRIBUTES } from '@anarchitects/common-angular-design/contracts';
+import {
+  ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES,
+  ANX_DESIGN_ROOT_MANAGED_KEYS,
+  pickAnxDesignRootContext,
+  resolveAnxDesignRootContext,
+  resolveAnxDesignRootValue,
+} from './design-root.contract';
+
+describe('design root contract', () => {
+  it('should manage only theme, density, and surface in v1', () => {
+    expect(ANX_DESIGN_ROOT_MANAGED_KEYS).toEqual([
+      'theme',
+      'density',
+      'surface',
+    ]);
+    expect(ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES).toEqual({
+      theme: ANX_DATA_ATTRIBUTES.theme,
+      density: ANX_DATA_ATTRIBUTES.density,
+      surface: ANX_DATA_ATTRIBUTES.surface,
+    });
+    expect(Object.values(ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES)).not.toContain(
+      ANX_DATA_ATTRIBUTES.layout,
+    );
+    expect(Object.values(ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES)).not.toContain(
+      ANX_DATA_ATTRIBUTES.columns,
+    );
+  });
+
+  it('should resolve precedence as input over attribute over config', () => {
+    expect(
+      resolveAnxDesignRootValue({
+        inputValue: 'input-theme',
+        attributeValue: 'attribute-theme',
+        configValue: 'config-theme',
+      }),
+    ).toEqual({
+      source: 'input',
+      value: 'input-theme',
+    });
+
+    expect(
+      resolveAnxDesignRootValue({
+        inputValue: null,
+        attributeValue: 'attribute-theme',
+        configValue: 'config-theme',
+      }),
+    ).toEqual({
+      source: 'attribute',
+      value: 'attribute-theme',
+    });
+
+    expect(
+      resolveAnxDesignRootValue({
+        inputValue: null,
+        attributeValue: null,
+        configValue: 'config-theme',
+      }),
+    ).toEqual({
+      source: 'config',
+      value: 'config-theme',
+    });
+  });
+
+  it('should resolve the managed root context by the fixed precedence rules', () => {
+    const config = pickAnxDesignRootContext({
+      theme: 'default',
+      density: 'comfortable',
+      surface: 'plain',
+      layout: 'grid',
+      columns: 3,
+    });
+
+    expect(
+      resolveAnxDesignRootContext({
+        config,
+        inputs: {
+          theme: 'input-theme',
+        },
+        attributes: {
+          density: 'compact',
+          surface: 'card',
+        },
+      }),
+    ).toEqual({
+      context: {
+        theme: 'input-theme',
+        density: 'compact',
+        surface: 'card',
+      },
+      sources: {
+        theme: 'input',
+        density: 'attribute',
+        surface: 'attribute',
+      },
+    });
+  });
+});

--- a/libs/common/angular/design/config/src/design-root.contract.ts
+++ b/libs/common/angular/design/config/src/design-root.contract.ts
@@ -1,0 +1,109 @@
+import {
+  ANX_DATA_ATTRIBUTES,
+  ANX_ROOT_CLASS,
+} from '@anarchitects/common-angular-design/contracts';
+import { DesignSystemConfig } from './config.tokens';
+
+export const ANX_DESIGN_ROOT_MANAGED_KEYS = [
+  'theme',
+  'density',
+  'surface',
+] as const;
+
+export type AnxDesignRootManagedKey =
+  (typeof ANX_DESIGN_ROOT_MANAGED_KEYS)[number];
+
+export type AnxDesignRootContext = Pick<
+  DesignSystemConfig,
+  AnxDesignRootManagedKey
+>;
+
+export const ANX_DESIGN_ROOT_HOST_CLASS = ANX_ROOT_CLASS;
+
+export const ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES = {
+  theme: ANX_DATA_ATTRIBUTES.theme,
+  density: ANX_DATA_ATTRIBUTES.density,
+  surface: ANX_DATA_ATTRIBUTES.surface,
+} as const satisfies Record<AnxDesignRootManagedKey, string>;
+
+export type AnxDesignRootValueSource = 'input' | 'attribute' | 'config';
+
+export type AnxDesignRootResolvedValue<T extends string = string> = {
+  source: AnxDesignRootValueSource;
+  value: T;
+};
+
+export type AnxDesignRootResolution = {
+  context: Record<AnxDesignRootManagedKey, string>;
+  sources: Record<AnxDesignRootManagedKey, AnxDesignRootValueSource>;
+};
+
+type AnxDesignRootValueOverrides = Partial<
+  Record<AnxDesignRootManagedKey, string | null | undefined>
+>;
+
+export function pickAnxDesignRootContext(
+  config: DesignSystemConfig,
+): AnxDesignRootContext {
+  return {
+    theme: config.theme,
+    density: config.density,
+    surface: config.surface,
+  };
+}
+
+export function resolveAnxDesignRootValue<T extends string>(options: {
+  inputValue?: T | null;
+  attributeValue?: T | null;
+  configValue: T;
+}): AnxDesignRootResolvedValue<T> {
+  if (hasExplicitValue(options.inputValue)) {
+    return {
+      source: 'input',
+      value: options.inputValue,
+    };
+  }
+
+  if (hasExplicitValue(options.attributeValue)) {
+    return {
+      source: 'attribute',
+      value: options.attributeValue,
+    };
+  }
+
+  return {
+    source: 'config',
+    value: options.configValue,
+  };
+}
+
+export function resolveAnxDesignRootContext(options: {
+  config: AnxDesignRootContext;
+  inputs?: AnxDesignRootValueOverrides;
+  attributes?: AnxDesignRootValueOverrides;
+}): AnxDesignRootResolution {
+  const context = {} as Record<AnxDesignRootManagedKey, string>;
+  const sources = {} as Record<
+    AnxDesignRootManagedKey,
+    AnxDesignRootValueSource
+  >;
+
+  for (const key of ANX_DESIGN_ROOT_MANAGED_KEYS) {
+    const resolved = resolveAnxDesignRootValue({
+      inputValue: options.inputs?.[key] ?? null,
+      attributeValue: options.attributes?.[key] ?? null,
+      configValue: options.config[key],
+    });
+
+    context[key] = resolved.value;
+    sources[key] = resolved.source;
+  }
+
+  return { context, sources };
+}
+
+function hasExplicitValue<T extends string>(
+  value: T | null | undefined,
+): value is T {
+  return value != null && value !== '';
+}

--- a/libs/common/angular/design/config/src/design-root.directive.spec.ts
+++ b/libs/common/angular/design/config/src/design-root.directive.spec.ts
@@ -1,0 +1,123 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideDesignSystemConfig } from './config.providers';
+import { AnxDesignRootDirective } from './design-root.directive';
+
+@Component({
+  imports: [AnxDesignRootDirective],
+  template: `
+    <section anarchitectsDesignRoot></section>
+    <section class="plain-host"></section>
+  `,
+})
+class DefaultDesignRootHostComponent {}
+
+@Component({
+  imports: [AnxDesignRootDirective],
+  template: `
+    <section
+      anarchitectsDesignRoot
+      data-anx-theme="manual-theme"
+      data-anx-density="compact"
+    ></section>
+  `,
+})
+class ManualAttributeDesignRootHostComponent {}
+
+@Component({
+  imports: [AnxDesignRootDirective],
+  template: `
+    <section
+      anarchitectsDesignRoot
+      data-anx-theme="manual-theme"
+      [designTheme]="'input-theme'"
+      [designDensity]="'compact'"
+      [designSurface]="'card'"
+    ></section>
+  `,
+})
+class InputOverrideDesignRootHostComponent {}
+
+describe('AnxDesignRootDirective', () => {
+  it('should require an explicit host element for root ownership', async () => {
+    await TestBed.configureTestingModule({
+      imports: [DefaultDesignRootHostComponent],
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'enterprise',
+          density: 'compact',
+          surface: 'card',
+          layout: 'grid',
+          columns: 3,
+        }),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(DefaultDesignRootHostComponent);
+    fixture.detectChanges();
+
+    const [designRoot, plainHost] = Array.from(
+      fixture.nativeElement.querySelectorAll('section'),
+    ) as HTMLElement[];
+
+    expect(designRoot.classList.contains('anx-root')).toBe(true);
+    expect(designRoot.getAttribute('data-anx-theme')).toBe('enterprise');
+    expect(designRoot.getAttribute('data-anx-density')).toBe('compact');
+    expect(designRoot.getAttribute('data-anx-surface')).toBe('card');
+    expect(designRoot.hasAttribute('data-anx-layout')).toBe(false);
+    expect(designRoot.hasAttribute('data-anx-columns')).toBe(false);
+    expect(plainHost.classList.contains('anx-root')).toBe(false);
+  });
+
+  it('should preserve explicit manual host attributes over provider values', async () => {
+    await TestBed.configureTestingModule({
+      imports: [ManualAttributeDesignRootHostComponent],
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'provider-theme',
+          density: 'comfortable',
+          surface: 'card',
+          layout: 'grid',
+          columns: 2,
+        }),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      ManualAttributeDesignRootHostComponent,
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('section') as HTMLElement;
+
+    expect(host.getAttribute('data-anx-theme')).toBe('manual-theme');
+    expect(host.getAttribute('data-anx-density')).toBe('compact');
+    expect(host.getAttribute('data-anx-surface')).toBe('card');
+  });
+
+  it('should allow directive inputs to override manual attributes and config', async () => {
+    await TestBed.configureTestingModule({
+      imports: [InputOverrideDesignRootHostComponent],
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'provider-theme',
+          density: 'comfortable',
+          surface: 'plain',
+          layout: 'list',
+          columns: 1,
+        }),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      InputOverrideDesignRootHostComponent,
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('section') as HTMLElement;
+
+    expect(host.getAttribute('data-anx-theme')).toBe('input-theme');
+    expect(host.getAttribute('data-anx-density')).toBe('compact');
+    expect(host.getAttribute('data-anx-surface')).toBe('card');
+  });
+});

--- a/libs/common/angular/design/config/src/design-root.directive.ts
+++ b/libs/common/angular/design/config/src/design-root.directive.ts
@@ -1,0 +1,63 @@
+import { Directive, ElementRef, computed, inject, input } from '@angular/core';
+import {
+  ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES,
+  AnxDesignRootManagedKey,
+  pickAnxDesignRootContext,
+  resolveAnxDesignRootValue,
+} from './design-root.contract';
+import { injectDesignSystemConfig } from './config.tokens';
+
+@Directive({
+  selector: '[anarchitectsDesignRoot]',
+  host: {
+    class: 'anx-root',
+    '[attr.data-anx-theme]': 'resolvedTheme()',
+    '[attr.data-anx-density]': 'resolvedDensity()',
+    '[attr.data-anx-surface]': 'resolvedSurface()',
+  },
+})
+export class AnxDesignRootDirective {
+  readonly designTheme = input<string | null>(null);
+  readonly designDensity = input<string | null>(null);
+  readonly designSurface = input<string | null>(null);
+
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly config = pickAnxDesignRootContext(
+    injectDesignSystemConfig(),
+  );
+  private readonly explicitAttributes = {
+    theme: this.readInitialAttribute('theme'),
+    density: this.readInitialAttribute('density'),
+    surface: this.readInitialAttribute('surface'),
+  } as const;
+
+  readonly resolvedTheme = computed(() => {
+    return resolveAnxDesignRootValue({
+      inputValue: this.designTheme(),
+      attributeValue: this.explicitAttributes.theme,
+      configValue: this.config.theme,
+    }).value;
+  });
+
+  readonly resolvedDensity = computed(() => {
+    return resolveAnxDesignRootValue({
+      inputValue: this.designDensity(),
+      attributeValue: this.explicitAttributes.density,
+      configValue: this.config.density,
+    }).value;
+  });
+
+  readonly resolvedSurface = computed(() => {
+    return resolveAnxDesignRootValue({
+      inputValue: this.designSurface(),
+      attributeValue: this.explicitAttributes.surface,
+      configValue: this.config.surface,
+    }).value;
+  });
+
+  private readInitialAttribute(key: AnxDesignRootManagedKey): string | null {
+    return this.elementRef.nativeElement.getAttribute(
+      ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES[key],
+    );
+  }
+}

--- a/libs/common/angular/design/config/src/document-dom-sync.providers.spec.ts
+++ b/libs/common/angular/design/config/src/document-dom-sync.providers.spec.ts
@@ -1,0 +1,117 @@
+import { ApplicationInitStatus } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ANX_DATA_ATTRIBUTES } from '@anarchitects/common-angular-design/contracts';
+import { provideDesignSystemConfig } from './config.providers';
+import { provideDocumentDesignSystemDomSync } from './document-dom-sync.providers';
+
+describe('document design-system DOM sync providers', () => {
+  const managedAttributes = [
+    ANX_DATA_ATTRIBUTES.theme,
+    ANX_DATA_ATTRIBUTES.density,
+    ANX_DATA_ATTRIBUTES.surface,
+  ] as const;
+
+  let originalClassName = '';
+  let originalAttributes: Record<
+    (typeof managedAttributes)[number],
+    string | null
+  >;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    originalClassName = document.documentElement.className;
+    originalAttributes = {
+      'data-anx-theme': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.theme,
+      ),
+      'data-anx-density': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.density,
+      ),
+      'data-anx-surface': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.surface,
+      ),
+    };
+
+    document.documentElement.className = '';
+    for (const attributeName of managedAttributes) {
+      document.documentElement.removeAttribute(attributeName);
+    }
+  });
+
+  afterEach(() => {
+    document.documentElement.className = originalClassName;
+    for (const attributeName of managedAttributes) {
+      const originalValue = originalAttributes[attributeName];
+      if (originalValue == null) {
+        document.documentElement.removeAttribute(attributeName);
+        continue;
+      }
+
+      document.documentElement.setAttribute(attributeName, originalValue);
+    }
+  });
+
+  it('should mark the document root and fill missing managed attributes from config', async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'provider-theme',
+          density: 'compact',
+          surface: 'card',
+          layout: 'grid',
+          columns: 4,
+        }),
+        ...provideDocumentDesignSystemDomSync(),
+      ],
+    }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+
+    expect(document.documentElement.classList.contains('anx-root')).toBe(true);
+    expect(document.documentElement.getAttribute('data-anx-theme')).toBe(
+      'provider-theme',
+    );
+    expect(document.documentElement.getAttribute('data-anx-density')).toBe(
+      'compact',
+    );
+    expect(document.documentElement.getAttribute('data-anx-surface')).toBe(
+      'card',
+    );
+    expect(document.documentElement.hasAttribute('data-anx-layout')).toBe(
+      false,
+    );
+    expect(document.documentElement.hasAttribute('data-anx-columns')).toBe(
+      false,
+    );
+  });
+
+  it('should preserve explicit document attributes over provider values', async () => {
+    document.documentElement.setAttribute('data-anx-theme', 'manual-theme');
+
+    await TestBed.configureTestingModule({
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'provider-theme',
+          density: 'comfortable',
+          surface: 'plain',
+          layout: 'list',
+          columns: 1,
+        }),
+        ...provideDocumentDesignSystemDomSync(),
+      ],
+    }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+
+    expect(document.documentElement.getAttribute('data-anx-theme')).toBe(
+      'manual-theme',
+    );
+    expect(document.documentElement.getAttribute('data-anx-density')).toBe(
+      'comfortable',
+    );
+    expect(document.documentElement.getAttribute('data-anx-surface')).toBe(
+      'plain',
+    );
+  });
+});

--- a/libs/common/angular/design/config/src/document-dom-sync.providers.ts
+++ b/libs/common/angular/design/config/src/document-dom-sync.providers.ts
@@ -1,0 +1,47 @@
+import { DOCUMENT } from '@angular/common';
+import { APP_INITIALIZER, Provider, inject } from '@angular/core';
+import {
+  ANX_DESIGN_ROOT_HOST_CLASS,
+  ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES,
+  ANX_DESIGN_ROOT_MANAGED_KEYS,
+  pickAnxDesignRootContext,
+} from './design-root.contract';
+import { injectDesignSystemConfig } from './config.tokens';
+
+export function provideDocumentDesignSystemDomSync(): Provider[] {
+  return [
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      useFactory: () => {
+        const documentRef = inject(DOCUMENT, { optional: true });
+        const config = pickAnxDesignRootContext(injectDesignSystemConfig());
+
+        return () => {
+          syncDocumentDesignSystemDom(documentRef, config);
+        };
+      },
+    },
+  ];
+}
+
+function syncDocumentDesignSystemDom(
+  documentRef: Document | null,
+  config: ReturnType<typeof pickAnxDesignRootContext>,
+): void {
+  const root = documentRef?.documentElement;
+  if (!root) {
+    return;
+  }
+
+  root.classList.add(ANX_DESIGN_ROOT_HOST_CLASS);
+
+  for (const key of ANX_DESIGN_ROOT_MANAGED_KEYS) {
+    const attributeName = ANX_DESIGN_ROOT_MANAGED_ATTRIBUTES[key];
+    if (root.hasAttribute(attributeName)) {
+      continue;
+    }
+
+    root.setAttribute(attributeName, config[key]);
+  }
+}

--- a/libs/common/angular/design/config/src/index.ts
+++ b/libs/common/angular/design/config/src/index.ts
@@ -1,2 +1,5 @@
 export * from './config.tokens';
 export * from './config.providers';
+export * from './design-root.contract';
+export * from './design-root.directive';
+export * from './document-dom-sync.providers';

--- a/libs/common/angular/design/config/src/public-api.spec.ts
+++ b/libs/common/angular/design/config/src/public-api.spec.ts
@@ -1,0 +1,17 @@
+import {
+  AnxDesignRootDirective as RootDesignRootDirective,
+  provideDocumentDesignSystemDomSync as provideRootDocumentDesignSystemDomSync,
+} from '@anarchitects/common-angular-design';
+import {
+  AnxDesignRootDirective,
+  provideDocumentDesignSystemDomSync,
+} from './index';
+
+describe('common-angular-design public api', () => {
+  it('should expose the design root contract APIs from config and root entry points', () => {
+    expect(RootDesignRootDirective).toBe(AnxDesignRootDirective);
+    expect(provideRootDocumentDesignSystemDomSync).toBe(
+      provideDocumentDesignSystemDomSync,
+    );
+  });
+});

--- a/libs/common/angular/design/contracts/README.md
+++ b/libs/common/angular/design/contracts/README.md
@@ -5,6 +5,10 @@ Public design-system contract for stable hooks and semantic naming.
 ## Exposes
 
 - Stable host data attributes (`data-anx-*`)
+- V1 managed root-sync subset for `theme`, `density`, and `surface`
 - Allowed values for density/surface/layout
 - Semantic class naming contract for future primitives and layouts
 - Type guards for contract-safe value checks
+
+`data-anx-layout` and `data-anx-columns` remain explicit host attributes in the
+current single-source theme-context slice.

--- a/libs/common/angular/design/package.json
+++ b/libs/common/angular/design/package.json
@@ -2,6 +2,7 @@
   "name": "@anarchitects/common-angular-design",
   "version": "0.0.3",
   "peerDependencies": {
+    "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0"
   },
   "sideEffects": false,

--- a/libs/common/angular/design/styles/README.md
+++ b/libs/common/angular/design/styles/README.md
@@ -13,5 +13,9 @@ applyAnxBaseStyles();
 Then scope design-system usage under the root class and hooks:
 
 ```html
-<section class="anx-root" data-anx-theme="default" data-anx-density="comfortable" data-anx-surface="plain" data-anx-layout="list" data-anx-columns="1"></section>
+<section anarchitectsDesignRoot data-anx-layout="list" data-anx-columns="1"></section>
 ```
+
+The `anarchitectsDesignRoot` directive is the canonical way to attach theme,
+density, and surface attributes. Existing manual `class="anx-root"` and
+`data-anx-*` attributes remain valid when an app needs explicit overrides.


### PR DESCRIPTION
Add the directive-first API contract for single-source theme context sync in common-angular-design. This introduces the explicit root-host directive, fallback document sync provider, precedence helpers, contract tests, and docs for theme/density/surface DOM sync.

Closes #216 Refs #202 Refs #203