### PR TITLE
feat(common-angular-design): make provider config auto-sync DOM theme context

### DIFF
--- a/libs/common/angular/design/README.md
+++ b/libs/common/angular/design/README.md
@@ -47,7 +47,7 @@ Consumers extend at the edges by:
 ### 1) Register context defaults
 
 ```ts
-import { provideDesignSystemConfig, provideDocumentDesignSystemDomSync } from '@anarchitects/common-angular-design/config';
+import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
 
 export const appConfig = {
   providers: [
@@ -58,8 +58,6 @@ export const appConfig = {
       layout: 'list',
       columns: 1,
     }),
-    // Optional fallback when an app cannot annotate its root shell element.
-    ...provideDocumentDesignSystemDomSync(),
   ],
 };
 ```
@@ -72,10 +70,10 @@ import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
 applyAnxBaseStyles();
 ```
 
-### 3) Scope usage with an explicit root host
+### 3) Render content without a required root host
 
 ```html
-<section anarchitectsDesignRoot data-anx-layout="list" data-anx-columns="1">
+<section data-anx-layout="list" data-anx-columns="1">
   <div class="anx-region anx-stack">
     <h2 class="anx-heading">Contact</h2>
     <p class="anx-text">A neutral foundation, ready for consumer theming.</p>
@@ -83,10 +81,14 @@ applyAnxBaseStyles();
 </section>
 ```
 
-`anarchitectsDesignRoot` is the canonical setup path. It manages `data-anx-theme`,
-`data-anx-density`, and `data-anx-surface` from the injected design config.
-`data-anx-layout` and `data-anx-columns` remain explicit host attributes in this
-slice.
+`provideDesignSystemConfig(...)` now applies `anx-root`,
+`data-anx-theme`, `data-anx-density`, and `data-anx-surface` to
+`document.documentElement` automatically during bootstrap.
+`data-anx-layout` and `data-anx-columns` remain explicit where layout scoping is
+needed.
+
+Use `anarchitectsDesignRoot` only when a subtree needs explicit local theme,
+density, or surface overrides.
 
 Existing apps can keep manual `data-anx-theme`, `data-anx-density`, and
 `data-anx-surface` attributes during migration. Explicit manual attributes stay

--- a/libs/common/angular/design/config/README.md
+++ b/libs/common/angular/design/config/README.md
@@ -4,7 +4,7 @@ Typed configuration and provider helpers for the shared Angular design-system co
 
 ## Usage
 
-Canonical setup uses an explicit app-shell host element:
+Canonical setup is provider-only:
 
 ```ts
 import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
@@ -20,15 +20,25 @@ providers: [
 ];
 ```
 
+`provideDesignSystemConfig(...)` now applies `anx-root`,
+`data-anx-theme`, `data-anx-density`, and `data-anx-surface` to
+`document.documentElement` during bootstrap.
+
+`layout` and `columns` remain explicit in v1. Set those attributes where layout
+scoping is required.
+
+Use the directive when a subtree needs its own scoped root:
+
 ```html
 <section anarchitectsDesignRoot data-anx-layout="grid" data-anx-columns="3"></section>
 ```
 
-`anarchitectsDesignRoot` manages `theme`, `density`, and `surface` on that
-explicit host.
-`layout` and `columns` remain explicit in v1.
+`anarchitectsDesignRoot` still resolves precedence as directive input, then
+explicit host attributes, then provider config.
 
-When a host app cannot annotate its shell template, use the document fallback:
+`provideDocumentDesignSystemDomSync()` remains available as a low-level compat
+helper. Using it alongside `provideDesignSystemConfig(...)` is harmless and
+idempotent:
 
 ```ts
 import { provideDesignSystemConfig, provideDocumentDesignSystemDomSync } from '@anarchitects/common-angular-design/config';

--- a/libs/common/angular/design/config/src/config.providers.spec.ts
+++ b/libs/common/angular/design/config/src/config.providers.spec.ts
@@ -1,4 +1,6 @@
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { ANX_DATA_ATTRIBUTES } from '@anarchitects/common-angular-design/contracts';
 import {
   DESIGN_SYSTEM_COLUMNS,
   DESIGN_SYSTEM_CONFIG,
@@ -13,19 +15,86 @@ import {
 } from './config.providers';
 
 describe('design-system providers', () => {
-  it('should provide defaults when no overrides are passed', () => {
+  const managedAttributes = [
+    ANX_DATA_ATTRIBUTES.theme,
+    ANX_DATA_ATTRIBUTES.density,
+    ANX_DATA_ATTRIBUTES.surface,
+  ] as const;
+
+  let originalClassName = '';
+  let originalAttributes: Record<
+    (typeof managedAttributes)[number],
+    string | null
+  >;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    originalClassName = document.documentElement.className;
+    originalAttributes = {
+      'data-anx-theme': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.theme,
+      ),
+      'data-anx-density': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.density,
+      ),
+      'data-anx-surface': document.documentElement.getAttribute(
+        ANX_DATA_ATTRIBUTES.surface,
+      ),
+    };
+
+    document.documentElement.className = '';
+    for (const attributeName of managedAttributes) {
+      document.documentElement.removeAttribute(attributeName);
+    }
+  });
+
+  afterEach(() => {
+    document.documentElement.className = originalClassName;
+    for (const attributeName of managedAttributes) {
+      const originalValue = originalAttributes[attributeName];
+      if (originalValue == null) {
+        document.documentElement.removeAttribute(attributeName);
+        continue;
+      }
+
+      document.documentElement.setAttribute(attributeName, originalValue);
+    }
+  });
+
+  it('should provide defaults and sync managed attributes when no overrides are passed', async () => {
     TestBed.configureTestingModule({
       providers: [...provideDesignSystemDefaults()],
     });
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
 
     expect(TestBed.inject(DESIGN_SYSTEM_THEME)).toBe('default');
     expect(TestBed.inject(DESIGN_SYSTEM_DENSITY)).toBe('comfortable');
     expect(TestBed.inject(DESIGN_SYSTEM_SURFACE)).toBe('plain');
     expect(TestBed.inject(DESIGN_SYSTEM_LAYOUT)).toBe('list');
     expect(TestBed.inject(DESIGN_SYSTEM_COLUMNS)).toBe(1);
+    expect(document.documentElement.classList.contains('anx-root')).toBe(true);
+    expect(document.documentElement.getAttribute('data-anx-theme')).toBe(
+      'default',
+    );
+    expect(document.documentElement.getAttribute('data-anx-density')).toBe(
+      'comfortable',
+    );
+    expect(document.documentElement.getAttribute('data-anx-surface')).toBe(
+      'plain',
+    );
+    expect(document.documentElement.hasAttribute('data-anx-layout')).toBe(
+      false,
+    );
+    expect(document.documentElement.hasAttribute('data-anx-columns')).toBe(
+      false,
+    );
   });
 
-  it('should allow explicit override precedence over defaults', () => {
+  it('should preserve explicit document attributes over provider sync', async () => {
+    document.documentElement.setAttribute('data-anx-theme', 'manual-theme');
+
     TestBed.configureTestingModule({
       providers: [
         ...provideDesignSystemConfig({
@@ -38,6 +107,8 @@ describe('design-system providers', () => {
       ],
     });
 
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+
     expect(TestBed.inject(DESIGN_SYSTEM_THEME)).toBe('enterprise');
     expect(TestBed.inject(DESIGN_SYSTEM_DENSITY)).toBe('compact');
     expect(TestBed.inject(DESIGN_SYSTEM_SURFACE)).toBe('card');
@@ -46,5 +117,14 @@ describe('design-system providers', () => {
 
     const mergedConfig = TestBed.inject(DESIGN_SYSTEM_CONFIG);
     expect(mergedConfig.theme).toBe('enterprise');
+    expect(document.documentElement.getAttribute('data-anx-theme')).toBe(
+      'manual-theme',
+    );
+    expect(document.documentElement.getAttribute('data-anx-density')).toBe(
+      'compact',
+    );
+    expect(document.documentElement.getAttribute('data-anx-surface')).toBe(
+      'card',
+    );
   });
 });

--- a/libs/common/angular/design/config/src/config.providers.ts
+++ b/libs/common/angular/design/config/src/config.providers.ts
@@ -9,6 +9,7 @@ import {
   DESIGN_SYSTEM_THEME,
   DesignSystemConfig,
 } from './config.tokens';
+import { provideDocumentDesignSystemDomSync } from './document-dom-sync.providers';
 
 export function provideDesignSystemConfig(
   overrides: Partial<DesignSystemConfig>,
@@ -25,6 +26,7 @@ export function provideDesignSystemConfig(
     { provide: DESIGN_SYSTEM_SURFACE, useValue: merged.surface },
     { provide: DESIGN_SYSTEM_LAYOUT, useValue: merged.layout },
     { provide: DESIGN_SYSTEM_COLUMNS, useValue: merged.columns },
+    ...provideDocumentDesignSystemDomSync(),
   ];
 }
 

--- a/libs/common/angular/design/config/src/design-root.directive.spec.ts
+++ b/libs/common/angular/design/config/src/design-root.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideDesignSystemConfig } from './config.providers';
 import { AnxDesignRootDirective } from './design-root.directive';
@@ -37,6 +37,23 @@ class ManualAttributeDesignRootHostComponent {}
   `,
 })
 class InputOverrideDesignRootHostComponent {}
+
+@Component({
+  imports: [AnxDesignRootDirective],
+  template: `
+    <section
+      anarchitectsDesignRoot
+      [designTheme]="theme()"
+      [designDensity]="density()"
+      [designSurface]="surface()"
+    ></section>
+  `,
+})
+class RuntimeInputUpdateDesignRootHostComponent {
+  readonly theme = signal('input-theme');
+  readonly density = signal('compact');
+  readonly surface = signal('card');
+}
 
 describe('AnxDesignRootDirective', () => {
   it('should require an explicit host element for root ownership', async () => {
@@ -119,5 +136,39 @@ describe('AnxDesignRootDirective', () => {
     expect(host.getAttribute('data-anx-theme')).toBe('input-theme');
     expect(host.getAttribute('data-anx-density')).toBe('compact');
     expect(host.getAttribute('data-anx-surface')).toBe('card');
+  });
+
+  it('should update host attributes when directive inputs change at runtime', async () => {
+    await TestBed.configureTestingModule({
+      imports: [RuntimeInputUpdateDesignRootHostComponent],
+      providers: [
+        ...provideDesignSystemConfig({
+          theme: 'provider-theme',
+          density: 'comfortable',
+          surface: 'plain',
+          layout: 'list',
+          columns: 1,
+        }),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(
+      RuntimeInputUpdateDesignRootHostComponent,
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('section') as HTMLElement;
+    expect(host.getAttribute('data-anx-theme')).toBe('input-theme');
+    expect(host.getAttribute('data-anx-density')).toBe('compact');
+    expect(host.getAttribute('data-anx-surface')).toBe('card');
+
+    fixture.componentInstance.theme.set('updated-theme');
+    fixture.componentInstance.density.set('comfortable');
+    fixture.componentInstance.surface.set('plain');
+    fixture.detectChanges();
+
+    expect(host.getAttribute('data-anx-theme')).toBe('updated-theme');
+    expect(host.getAttribute('data-anx-density')).toBe('comfortable');
+    expect(host.getAttribute('data-anx-surface')).toBe('plain');
   });
 });

--- a/libs/common/angular/design/config/src/document-dom-sync.providers.spec.ts
+++ b/libs/common/angular/design/config/src/document-dom-sync.providers.spec.ts
@@ -52,7 +52,7 @@ describe('document design-system DOM sync providers', () => {
     }
   });
 
-  it('should mark the document root and fill missing managed attributes from config', async () => {
+  it('should remain idempotent when the compat helper is combined with provider auto-sync', async () => {
     await TestBed.configureTestingModule({
       providers: [
         ...provideDesignSystemConfig({
@@ -86,7 +86,7 @@ describe('document design-system DOM sync providers', () => {
     );
   });
 
-  it('should preserve explicit document attributes over provider values', async () => {
+  it('should preserve explicit document attributes when both sync paths are registered', async () => {
     document.documentElement.setAttribute('data-anx-theme', 'manual-theme');
 
     await TestBed.configureTestingModule({

--- a/libs/common/angular/design/styles/README.md
+++ b/libs/common/angular/design/styles/README.md
@@ -10,12 +10,14 @@ import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
 applyAnxBaseStyles();
 ```
 
-Then scope design-system usage under the root class and hooks:
+With provider-driven sync, the root class and managed theme attributes are
+applied to `document.documentElement` automatically. Render content normally and
+set explicit layout attributes only where needed:
 
 ```html
-<section anarchitectsDesignRoot data-anx-layout="list" data-anx-columns="1"></section>
+<section data-anx-layout="list" data-anx-columns="1"></section>
 ```
 
-The `anarchitectsDesignRoot` directive is the canonical way to attach theme,
-density, and surface attributes. Existing manual `class="anx-root"` and
-`data-anx-*` attributes remain valid when an app needs explicit overrides.
+Use `anarchitectsDesignRoot` only when a subtree needs explicit local theme,
+density, or surface overrides. Existing manual `class="anx-root"` and
+`data-anx-*` attributes remain valid when an app needs explicit control.


### PR DESCRIPTION
Make provideDesignSystemConfig(...) the standard runtime path for design-context DOM sync by applying anx-root plus managed data-anx attributes to document.documentElement during bootstrap. Keep the compat helper idempotent, preserve directive-based scoped overrides, extend unit coverage for provider and directive runtime behavior, and update docs to the provider-first setup.

Closes #217 Refs #202 Refs #203