### PR TITLE
docs(common-angular-design): publish single-source theme migration guide and canonical setup

### DIFF
--- a/docs/guides/design-ui-systems.md
+++ b/docs/guides/design-ui-systems.md
@@ -40,6 +40,57 @@ Example:
 }
 ```
 
+## Single-Source Theme Setup
+
+Use one canonical app-bootstrap path for shared design context:
+
+1. Apply base styles once before rendering.
+2. Register `provideDesignSystemConfig(...)` at app root.
+3. Avoid manual `data-anx-theme`, `data-anx-density`, and `data-anx-surface`
+   on the root in new setups.
+
+Example:
+
+```ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
+import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
+
+applyAnxBaseStyles();
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...provideDesignSystemConfig({
+      theme: 'default',
+      density: 'comfortable',
+      surface: 'plain',
+      layout: 'list',
+      columns: 1,
+    }),
+  ],
+});
+```
+
+The provider applies `anx-root`, `data-anx-theme`, `data-anx-density`, and
+`data-anx-surface` on `document.documentElement` during bootstrap.
+
+`data-anx-layout` and `data-anx-columns` remain explicit where local layout
+scope is required.
+
+For migrations from manual attributes, use the
+[Theme Migration Guide](/guides/theme-migration.html).
+
+### Precedence Rules
+
+For managed root values (`theme`, `density`, `surface`) the resolution order is:
+
+1. Directive input (`designTheme`, `designDensity`, `designSurface`)
+2. Explicit host/root attribute value (`data-anx-*`)
+3. Provider configuration (`provideDesignSystemConfig`)
+
+This keeps migration safe because existing explicit attributes remain
+authoritative.
+
 ## Composition Contracts
 
 Use `@anarchitects/common-angular-ui-composition` for stable projection contracts:
@@ -78,17 +129,17 @@ Use `@anarchitects/common-angular-ui-layouts` when runtime layout selection is r
 
 ## Domain Integration Matrix
 
-| Domain Package | Role | Design/UI System Integration |
-| --- | --- | --- |
-| `@anarchitects/forms-angular` | Dynamic form/list/detail flows | Consumes shared composition, primitives, and layout runtime contracts |
-| `@anarchitects/auth-angular` | Auth feature orchestration and domain UI | Uses shared design tokens/primitives and contract-safe state composition |
-| `@anarchitects/forms-nest` | Forms API/service backend | Must preserve contract stability used by frontend layouts and form rendering |
-| `@anarchitects/auth-nest` | Auth lifecycle backend | Must preserve contract stability used by frontend state/feature and policy flows |
+| Domain Package                | Role                                     | Design/UI System Integration                                                     |
+| ----------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------- |
+| `@anarchitects/forms-angular` | Dynamic form/list/detail flows           | Consumes shared composition, primitives, and layout runtime contracts            |
+| `@anarchitects/auth-angular`  | Auth feature orchestration and domain UI | Uses shared design tokens/primitives and contract-safe state composition         |
+| `@anarchitects/forms-nest`    | Forms API/service backend                | Must preserve contract stability used by frontend layouts and form rendering     |
+| `@anarchitects/auth-nest`     | Auth lifecycle backend                   | Must preserve contract stability used by frontend state/feature and policy flows |
 
 ## Cookbook Patterns
 
 - Pattern: baseline app setup
-  register design config and base styles before rendering domain UI.
+  apply base styles first, then register provider config before rendering domain UI.
 - Pattern: product theming
   apply token/theme overrides in app shell, not shared packages.
 - Pattern: projection stability
@@ -108,11 +159,12 @@ Use `@anarchitects/common-angular-ui-layouts` when runtime layout selection is r
 
 ## Adoption Checklist
 
-- Add `@anarchitects/common-angular-design` and apply base style bootstrap.
+- Add `@anarchitects/common-angular-design`, call `applyAnxBaseStyles()`, and register `provideDesignSystemConfig(...)` in app providers.
 - Adopt `@anarchitects/common-angular-ui-composition` slot/template contracts in shared and domain UI.
 - Use `@anarchitects/common-angular-ui-primitives` as base visual building blocks.
 - Add `@anarchitects/common-angular-ui-layouts` only when runtime-selectable layout behavior is required.
 - Keep forms and auth frontend packages aligned with backend contracts (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`, `@anarchitects/forms-nest`, `@anarchitects/auth-nest`).
+- Use [Theme Migration Guide](/guides/theme-migration.html) when moving existing apps away from manual root `data-anx-*` setup.
 - Validate docs and generated outputs:
   `yarn nx run docs-hub:validate-content`,
   `yarn nx run docs-hub:build`,

--- a/docs/guides/theme-migration.md
+++ b/docs/guides/theme-migration.md
@@ -1,0 +1,109 @@
+# Theme Migration Guide
+
+## Intent
+
+This guide explains how to migrate to a single-source theme setup for
+`@anarchitects/common-angular-design`.
+
+Goal:
+
+- Keep one canonical setup path for new apps.
+- Migrate existing apps away from manual root `data-anx-*` attributes safely.
+- Preserve backward compatibility during rollout.
+
+## Canonical Setup
+
+Use this app-bootstrap sequence:
+
+1. Call `applyAnxBaseStyles()` once before app render.
+2. Register `provideDesignSystemConfig(...)` in app providers.
+3. Keep `data-anx-layout` and `data-anx-columns` explicit only where local
+   layout scope is needed.
+
+```ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
+import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
+
+applyAnxBaseStyles();
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...provideDesignSystemConfig({
+      theme: 'default',
+      density: 'comfortable',
+      surface: 'plain',
+      layout: 'list',
+      columns: 1,
+    }),
+  ],
+});
+```
+
+## Before and After
+
+Before (manual root attributes):
+
+```html
+<html
+  class="anx-root"
+  data-anx-theme="ocean"
+  data-anx-density="compact"
+  data-anx-surface="card"
+>
+  ...
+</html>
+```
+
+After (provider-driven root attributes):
+
+```ts
+providers: [
+  ...provideDesignSystemConfig({
+    theme: 'ocean',
+    density: 'compact',
+    surface: 'card',
+  }),
+];
+```
+
+The provider writes managed attributes on `document.documentElement` during
+bootstrap.
+
+## Resolution Precedence
+
+Managed values (`theme`, `density`, `surface`) resolve in this order:
+
+1. Directive input (`designTheme`, `designDensity`, `designSurface`)
+2. Explicit attribute value (`data-anx-*`)
+3. Provider config value
+
+This precedence applies to subtree overrides with
+`anarchitectsDesignRoot` and supports incremental migration.
+
+## Backward Compatibility
+
+Backward compatibility is intentionally preserved:
+
+- Existing manual `data-anx-theme`, `data-anx-density`, and `data-anx-surface`
+  remain supported.
+- Explicit manual attributes stay authoritative over provider defaults.
+- Mixed mode is valid during migration windows.
+
+## Recommended Migration Sequence
+
+1. Add provider setup in bootstrap and keep existing manual attributes.
+2. Verify runtime output still matches expected theme context.
+3. Remove manual root `data-anx-*` attributes when provider values are verified.
+4. Keep explicit manual attributes only where deliberate overrides are required.
+
+## Storybook Note
+
+Storybook often uses local decorators that set `data-anx-*` in story wrappers.
+That pattern is valid for story isolation and does not replace canonical
+app-bootstrap setup.
+
+## Related Guides
+
+- [Design/UI Systems Guide](/guides/design-ui-systems.html)
+- [Angular Guide](/guides/angular.html)

--- a/libs/common/angular/design/README.md
+++ b/libs/common/angular/design/README.md
@@ -44,7 +44,15 @@ Consumers extend at the edges by:
 
 ## Quickstart
 
-### 1) Register context defaults
+### 1) Apply base styles before render
+
+```ts
+import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
+
+applyAnxBaseStyles();
+```
+
+### 2) Register context defaults
 
 ```ts
 import { provideDesignSystemConfig } from '@anarchitects/common-angular-design/config';
@@ -62,15 +70,7 @@ export const appConfig = {
 };
 ```
 
-### 2) Apply base styles
-
-```ts
-import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
-
-applyAnxBaseStyles();
-```
-
-### 3) Render content without a required root host
+### 3) Render content without a required manual root host
 
 ```html
 <section data-anx-layout="list" data-anx-columns="1">
@@ -93,6 +93,9 @@ density, or surface overrides.
 Existing apps can keep manual `data-anx-theme`, `data-anx-density`, and
 `data-anx-surface` attributes during migration. Explicit manual attributes stay
 authoritative over provider-derived defaults.
+
+For migration steps and before/after examples, see
+`docs/guides/theme-migration.md`.
 
 ## Usage
 

--- a/libs/common/angular/design/config/README.md
+++ b/libs/common/angular/design/config/README.md
@@ -30,7 +30,11 @@ scoping is required.
 Use the directive when a subtree needs its own scoped root:
 
 ```html
-<section anarchitectsDesignRoot data-anx-layout="grid" data-anx-columns="3"></section>
+<section
+  anarchitectsDesignRoot
+  data-anx-layout="grid"
+  data-anx-columns="3"
+></section>
 ```
 
 `anarchitectsDesignRoot` still resolves precedence as directive input, then
@@ -41,7 +45,10 @@ helper. Using it alongside `provideDesignSystemConfig(...)` is harmless and
 idempotent:
 
 ```ts
-import { provideDesignSystemConfig, provideDocumentDesignSystemDomSync } from '@anarchitects/common-angular-design/config';
+import {
+  provideDesignSystemConfig,
+  provideDocumentDesignSystemDomSync,
+} from '@anarchitects/common-angular-design/config';
 
 providers: [
   ...provideDesignSystemConfig({
@@ -57,3 +64,25 @@ providers: [
 
 Existing manual `data-anx-theme`, `data-anx-density`, and `data-anx-surface`
 attributes remain supported and win over provider-derived defaults.
+
+## Resolution precedence
+
+Managed values (`theme`, `density`, `surface`) resolve in this order:
+
+1. Directive input (`designTheme`, `designDensity`, `designSurface`)
+2. Explicit host attribute (`data-anx-*`)
+3. Provider config (`provideDesignSystemConfig`)
+
+This precedence enables safe incremental migration from manual root attributes
+to provider-based setup.
+
+## Setup decision matrix
+
+| Scenario                          | Preferred setup                                             |
+| --------------------------------- | ----------------------------------------------------------- |
+| App-wide defaults at bootstrap    | `provideDesignSystemConfig(...)`                            |
+| Local subtree override            | `anarchitectsDesignRoot` directive with optional inputs     |
+| Temporary migration compatibility | Keep explicit `data-anx-*` until provider path is validated |
+| Storybook isolated story wrapper  | Local decorator attributes for story context                |
+
+Migration guide: `docs/guides/theme-migration.md`.

--- a/libs/common/angular/design/styles/README.md
+++ b/libs/common/angular/design/styles/README.md
@@ -10,6 +10,8 @@ import { applyAnxBaseStyles } from '@anarchitects/common-angular-design/styles';
 applyAnxBaseStyles();
 ```
 
+Call `applyAnxBaseStyles()` once during app bootstrap before rendering UI.
+
 With provider-driven sync, the root class and managed theme attributes are
 applied to `document.documentElement` automatically. Render content normally and
 set explicit layout attributes only where needed:
@@ -21,3 +23,6 @@ set explicit layout attributes only where needed:
 Use `anarchitectsDesignRoot` only when a subtree needs explicit local theme,
 density, or surface overrides. Existing manual `class="anx-root"` and
 `data-anx-*` attributes remain valid when an app needs explicit control.
+
+For migration guidance away from manual root attributes, see
+`docs/guides/theme-migration.md`.

--- a/libs/storybook/angular/README.md
+++ b/libs/storybook/angular/README.md
@@ -1,3 +1,27 @@
 # storybook-angular
 
-This library was generated with [Nx](https://nx.dev).
+Storybook host for Angular library stories in this workspace.
+
+## Purpose
+
+This package configures Storybook rendering context, including design-theme
+wrapping used by component stories.
+
+## Theme setup in Storybook
+
+Storybook uses decorator-level wrappers and local `data-anx-*` attributes to
+set story context. This is intentional for isolated story rendering.
+
+This differs from application bootstrap, where canonical setup is:
+
+1. `applyAnxBaseStyles()` before render
+2. `provideDesignSystemConfig(...)` at app root
+
+## Guidance
+
+- Use Storybook decorators for story isolation and toolbar-driven preview
+  controls.
+- Do not treat Storybook wrapper attributes as the canonical app-consumer setup.
+- For migration and canonical setup details, use:
+  - `docs/guides/design-ui-systems.md`
+  - `docs/guides/theme-migration.md`


### PR DESCRIPTION
- Add dedicated theme-migration.md guide with canonical bootstrap example, before/after comparison, resolution precedence rules, backward compatibility notes, 4-step migration sequence, and Storybook guidance
- Extend design-ui-systems.md with Single-Source Theme Setup section and updated adoption checklist
- Reorder quickstart in design README to lead with applyAnxBaseStyles() step
- Add resolution precedence section and setup decision matrix to config README
- Add lifecycle timing note and migration link to styles README
- Replace Storybook README placeholder with theme setup and isolation guidance

Closes #219 Refs #202 Refs #203