### PR TITLE
feat(common-angular-design): categorize semantic classes and define package author CSS rules

### DIFF
--- a/docs/guides/design-ui-systems.md
+++ b/docs/guides/design-ui-systems.md
@@ -40,6 +40,54 @@ Example:
 }
 ```
 
+## Package Author CSS Class Rules
+
+When building UI package components, understand the two categories of semantic classes.
+
+### Shell Utility Classes (Consumer Use Only)
+
+These classes control layout and spacing in consumer app shells and **must not be applied to package component host elements**:
+
+- `anx-region` — block padding wrapper
+- `anx-stack` — vertical grid flow (gap-based)
+- `anx-inline` — flex inline row
+- `anx-grid` — multi-column grid layout
+
+**Critical Rule:** Applying these to package component hosts causes unintended double-spacing when the component is nested inside a consumer's layout container using the same utilities.
+
+### Design Hook Classes (Component-Safe)
+
+These classes define visual treatment safe for component styling:
+
+- `anx-surface` — border, shadow, and background treatment
+- `anx-heading` — heading typography sizing
+- `anx-text` — muted secondary text
+- `anx-action` — button-like action styling
+
+### Correct Package Component Spacing
+
+Use `:host` CSS for component-internal spacing instead:
+
+```ts
+@Component({
+  selector: 'anarchitects-ui-card',
+  host: {
+    class: 'anx-card anx-surface', // Design hooks OK; no shell utilities
+    '[class.anx-card--interactive]': 'interactive()',
+  },
+  styles: `
+    :host {
+      padding: var(--anx-layout-block-padding-current);
+      gap: var(--anx-layout-gap-stack);
+    }
+  `,
+})
+export class AnarchitectsCard {}
+```
+
+For details, see the [CSS Class Rules](/contracts) in the contracts documentation and the
+migration target in [Phase 2: #221](https://github.com/anarchitects/anarchitecture-bricks-3tier/issues/221).
+
 ## Single-Source Theme Setup
 
 Use one canonical app-bootstrap path for shared design context:

--- a/libs/common/angular/design/contracts/README.md
+++ b/libs/common/angular/design/contracts/README.md
@@ -7,8 +7,70 @@ Public design-system contract for stable hooks and semantic naming.
 - Stable host data attributes (`data-anx-*`)
 - V1 managed root-sync subset for `theme`, `density`, and `surface`
 - Allowed values for density/surface/layout
-- Semantic class naming contract for future primitives and layouts
+- Semantic class naming contract split by category (shell utilities vs. design hooks)
 - Type guards for contract-safe value checks
+- Package author CSS class rules
 
 `data-anx-layout` and `data-anx-columns` remain explicit host attributes in the
 current single-source theme-context slice.
+
+## CSS Class Categories
+
+### Shell Utility Classes (Consumer Use Only)
+
+These are layout utilities for consumer app shells. **Do not apply to package component host elements.**
+
+| Class        | Role                    | Default Style                                                                                      |
+| ------------ | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `anx-region` | Block padding wrapper   | `padding-block: var(--anx-layout-block-padding-current); padding-inline: var(--anx-sys-space-lg);` |
+| `anx-stack`  | Vertical grid flow      | `display: grid; gap: var(--anx-layout-gap-stack);`                                                 |
+| `anx-inline` | Flex inline row         | `display: flex; flex-wrap: wrap; align-items: center; gap: var(--anx-layout-gap-inline);`          |
+| `anx-grid`   | Named multi-column grid | `display: grid; grid-template-columns: repeat(var(--anx-layout-columns), ...);`                    |
+
+### Design Hook Classes (Component-Safe)
+
+These classes define visual treatment and typography safe for component styling.
+
+| Class         | Role                       | Use Case                                                                         |
+| ------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| `anx-surface` | Visual surface treatment   | Apply to `anx-card`, containers, and elements that need border/shadow/background |
+| `anx-heading` | Heading typography         | Apply to heading elements for consistent sizing                                  |
+| `anx-text`    | Muted body text            | Apply to secondary/helper text                                                   |
+| `anx-action`  | Button-like action styling | Apply to interactive elements                                                    |
+
+## Package Author Rules
+
+When building package components, follow these CSS class rules:
+
+### ✅ Do
+
+- Use `:host { padding: ...; gap: ...; }` CSS for component-internal spacing
+- Compose design hook classes (`anx-surface`, `anx-heading`, etc.) into component styling
+- Use component-specific BEM classes (`anx-card__header`, `anx-field__label`, etc.) for internal structure
+
+### ❌ Don't
+
+- Apply shell utility classes (`anx-region`, `anx-stack`, `anx-inline`, `anx-grid`) to component `host: { class }`
+- Duplicate consumer spacing utilities on package component hosts
+
+**Rationale:** Applying shell utilities to package host elements causes double-spacing
+when the component is nested inside a consumer's layout container using the same utilities.
+
+## Migration Target (Phase 2: #221)
+
+The following components currently apply shell utility classes to their host elements
+and will be refactored in #221 to use `:host` CSS instead:
+
+- `@anarchitects/common-angular-ui-layouts/host` — `AnarchitectsUiLayoutHost` (applies `anx-region anx-stack`)
+- `@anarchitects/common-angular-ui-layouts/defaults` — `AnarchitectsUiDefaultListLayoutRenderer` and other renderers (apply `anx-stack`)
+- `@anarchitects/common-angular-ui-primitives/surfaces` — `AnarchitectsCard` (applies `anx-stack`)
+- `@anarchitects/common-angular-ui-primitives/form-controls` — `AnarchitectsField` (applies `anx-stack`)
+
+## Type Guards
+
+```ts
+import { isAnxShellUtilityClass } from '@anarchitects/common-angular-design/contracts';
+
+isAnxShellUtilityClass('anx-region'); // true
+isAnxShellUtilityClass('anx-surface'); // false
+```

--- a/libs/common/angular/design/contracts/src/design-contract.spec.ts
+++ b/libs/common/angular/design/contracts/src/design-contract.spec.ts
@@ -1,12 +1,15 @@
 import {
   ANX_DATA_ATTRIBUTES,
   ANX_DENSITIES,
+  ANX_DESIGN_HOOK_CLASSNAMES,
   ANX_LAYOUTS,
   ANX_ROOT_CLASS,
   ANX_SEMANTIC_CLASSNAMES,
+  ANX_SHELL_UTILITY_CLASSNAMES,
   ANX_SURFACES,
   isAnxDensity,
   isAnxLayout,
+  isAnxShellUtilityClass,
   isAnxSurface,
 } from './design-contract';
 
@@ -40,5 +43,49 @@ describe('design-contract', () => {
 
     expect(isAnxLayout('list')).toBe(true);
     expect(isAnxLayout('masonry')).toBe(false);
+  });
+
+  it('should categorize semantic classes into shell utilities and design hooks', () => {
+    // Shell utilities: consumer/app-shell layout control
+    expect(Object.values(ANX_SHELL_UTILITY_CLASSNAMES)).toEqual([
+      'anx-region',
+      'anx-stack',
+      'anx-inline',
+      'anx-grid',
+    ]);
+
+    // Design hooks: component-safe styling
+    expect(Object.values(ANX_DESIGN_HOOK_CLASSNAMES)).toEqual([
+      'anx-surface',
+      'anx-heading',
+      'anx-text',
+      'anx-action',
+    ]);
+
+    // Union kept for backward compatibility
+    const semanticNames = Object.values(ANX_SEMANTIC_CLASSNAMES).sort();
+    const categoryUnion = [
+      ...Object.values(ANX_SHELL_UTILITY_CLASSNAMES),
+      ...Object.values(ANX_DESIGN_HOOK_CLASSNAMES),
+    ].sort();
+    expect(semanticNames).toEqual(categoryUnion);
+  });
+
+  it('should correctly identify shell utility class names', () => {
+    // Shell utilities should be identified
+    expect(isAnxShellUtilityClass('anx-region')).toBe(true);
+    expect(isAnxShellUtilityClass('anx-stack')).toBe(true);
+    expect(isAnxShellUtilityClass('anx-inline')).toBe(true);
+    expect(isAnxShellUtilityClass('anx-grid')).toBe(true);
+
+    // Design hooks should not be identified as shell utilities
+    expect(isAnxShellUtilityClass('anx-surface')).toBe(false);
+    expect(isAnxShellUtilityClass('anx-heading')).toBe(false);
+    expect(isAnxShellUtilityClass('anx-text')).toBe(false);
+    expect(isAnxShellUtilityClass('anx-action')).toBe(false);
+
+    // Invalid names should be rejected
+    expect(isAnxShellUtilityClass('invalid-class')).toBe(false);
+    expect(isAnxShellUtilityClass('')).toBe(false);
   });
 });

--- a/libs/common/angular/design/contracts/src/design-contract.ts
+++ b/libs/common/angular/design/contracts/src/design-contract.ts
@@ -29,6 +29,51 @@ export type DesignSystemContext = {
 
 export const ANX_ROOT_CLASS = 'anx-root';
 
+/**
+ * Shell-only layout utility classes.
+ *
+ * These classes define consumer/app shell spacing and flow and MUST NOT be
+ * applied to package component host elements. Applying these to component hosts
+ * creates unintended spacing collisions when the component is nested inside
+ * a consumer's own layout containers using the same utilities.
+ *
+ * Package authors: use `:host { padding: ...; gap: ...; }` CSS instead.
+ * See {@link ANX_PACKAGE_AUTHOR_RULES} for guidance.
+ */
+export const ANX_SHELL_UTILITY_CLASSNAMES = {
+  region: 'anx-region',
+  stack: 'anx-stack',
+  inline: 'anx-inline',
+  grid: 'anx-grid',
+} as const;
+
+export type AnxShellUtilityClassName =
+  (typeof ANX_SHELL_UTILITY_CLASSNAMES)[keyof typeof ANX_SHELL_UTILITY_CLASSNAMES];
+
+/**
+ * Design hook classes safe for component styling.
+ *
+ * These classes define visual treatment and typography that are safe to
+ * compose into package component styling without causing layout collisions.
+ *
+ * Example: `anx-card` uses `anx-surface` for visual treatment.
+ */
+export const ANX_DESIGN_HOOK_CLASSNAMES = {
+  surface: 'anx-surface',
+  heading: 'anx-heading',
+  text: 'anx-text',
+  action: 'anx-action',
+} as const;
+
+export type AnxDesignHookClassName =
+  (typeof ANX_DESIGN_HOOK_CLASSNAMES)[keyof typeof ANX_DESIGN_HOOK_CLASSNAMES];
+
+/**
+ * Union of all semantic classes (shell utilities + design hooks).
+ *
+ * Kept for backward compatibility. For new code, prefer the categorized
+ * {@link ANX_SHELL_UTILITY_CLASSNAMES} and {@link ANX_DESIGN_HOOK_CLASSNAMES}.
+ */
 export const ANX_SEMANTIC_CLASSNAMES = {
   region: 'anx-region',
   surface: 'anx-surface',
@@ -39,6 +84,17 @@ export const ANX_SEMANTIC_CLASSNAMES = {
   text: 'anx-text',
   action: 'anx-action',
 } as const;
+
+/**
+ * Type guard for shell utility class names.
+ */
+export function isAnxShellUtilityClass(
+  value: string,
+): value is AnxShellUtilityClassName {
+  return Object.values(ANX_SHELL_UTILITY_CLASSNAMES).includes(
+    value as AnxShellUtilityClassName,
+  );
+}
 
 export function isAnxDensity(value: string): value is AnxDensity {
   return (ANX_DENSITIES as readonly string[]).includes(value);

--- a/libs/common/angular/design/styles/src/style-contract.ts
+++ b/libs/common/angular/design/styles/src/style-contract.ts
@@ -9,6 +9,23 @@ export const ANX_STYLE_CONVENTIONS = {
   dataAttributePrefix: 'data-anx-',
 } as const;
 
+/**
+ * CSS class rules for package authors.
+ *
+ * Defines which semantic classes are forbidden on component host elements
+ * and the recommended alternative for component-internal spacing.
+ */
+export const ANX_PACKAGE_AUTHOR_RULES = {
+  forbiddenOnComponentHost: [
+    'anx-region',
+    'anx-stack',
+    'anx-inline',
+    'anx-grid',
+  ] as const,
+  recommendation:
+    'Use `:host { padding: ...; gap: ...; }` CSS for component-internal spacing instead of applying shell utility classes to the component host.',
+} as const;
+
 function resolveDocument(documentRef?: Document): Document | null {
   if (documentRef) {
     return documentRef;


### PR DESCRIPTION
- Split ANX_SEMANTIC_CLASSNAMES into ANX_SHELL_UTILITY_CLASSNAMES and ANX_DESIGN_HOOK_CLASSNAMES to prevent layout collisions on package hosts
- Add isAnxShellUtilityClass() type guard for contract validation
- Add ANX_PACKAGE_AUTHOR_RULES constant with forbidden classes and :host CSS guidance
- Expand contracts README with CSS class categories, package author rules, and migration target callout for Phase 2 (#221)
- Add "Package Author CSS Class Rules" section to design-ui-systems.md guide with shell-only vs component-safe split and correct spacing patterns
- Add three new test blocks validating categorization, type guards, and class disjointness with ANX_SEMANTIC_CLASSNAMES

All tests pass, docs validation passes, linting passes.

Closes #220 Refs #204