### PR TITLE
feat(common-angular-ui-layouts,common-angular-ui-primitives): remove shell utility class dependency from hosts and internal templates

### DIFF
--- a/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.css
+++ b/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.css
@@ -1,9 +1,29 @@
 :host {
-  display: block;
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
+}
+
+.anx-default-layout__toolbar,
+.anx-default-layout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--anx-layout-gap-inline);
+}
+
+.anx-default-layout__actions {
+  justify-content: flex-end;
 }
 
 .anx-default-layout__detail-sidebar {
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
   grid-template-columns: minmax(0, 2fr) minmax(16rem, 1fr);
+}
+
+.anx-default-layout__detail-page {
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
 }
 
 .anx-default-layout__detail-side {

--- a/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.html
+++ b/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.html
@@ -5,7 +5,7 @@
 }
 
 @if (toolbarTemplate(); as templateRef) {
-  <div class="anx-default-layout__toolbar anx-inline" data-anx-slot="toolbar">
+  <div class="anx-default-layout__toolbar" data-anx-slot="toolbar">
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   </div>
 }
@@ -23,7 +23,7 @@
   }
   @case ('sidebar') {
     <div
-      class="anx-default-layout__detail-sidebar anx-grid"
+      class="anx-default-layout__detail-sidebar"
       [style.--anx-layout-columns]="2"
     >
       <section data-anx-slot="content" class="anx-default-layout__detail-main">
@@ -52,10 +52,7 @@
     </div>
   }
   @default {
-    <section
-      data-anx-slot="content"
-      class="anx-default-layout__detail-page anx-stack"
-    >
+    <section data-anx-slot="content" class="anx-default-layout__detail-page">
       <ng-container
         *ngTemplateOutlet="
           requiredContentTemplate();
@@ -67,7 +64,7 @@
 }
 
 @if (actionsTemplate(); as templateRef) {
-  <div class="anx-default-layout__actions anx-inline" data-anx-slot="actions">
+  <div class="anx-default-layout__actions" data-anx-slot="actions">
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   </div>
 }

--- a/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.ts
+++ b/libs/common/angular/ui-layouts/defaults/src/detail-layout-renderer.component.ts
@@ -18,7 +18,7 @@ import { resolveLayoutVariant, resolveTemplate } from './layout-renderer.utils';
   styleUrl: './detail-layout-renderer.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-default-layout anx-default-layout--detail anx-stack',
+    class: 'anx-default-layout anx-default-layout--detail',
     '[attr.data-layout-variant]': 'layoutVariant()',
     'attr.data-anx-component': '"layout-detail"',
   },

--- a/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.css
+++ b/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.css
@@ -1,5 +1,6 @@
 :host {
-  display: block;
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
 }
 
 .anx-default-layout__header,
@@ -11,11 +12,28 @@
 .anx-default-layout__form-inline,
 .anx-default-layout__form-stacked,
 .anx-default-layout__form-card {
+  display: grid;
   gap: var(--anx-layout-gap-stack);
 }
 
 .anx-default-layout__form-grid {
+  display: grid;
   grid-template-columns: repeat(var(--anx-layout-columns), minmax(0, 1fr));
+}
+
+.anx-default-layout__toolbar,
+.anx-default-layout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--anx-layout-gap-inline);
+}
+
+.anx-default-layout__form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--anx-layout-gap-inline);
 }
 
 .anx-default-layout__form-inline > * {

--- a/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.html
+++ b/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.html
@@ -5,7 +5,7 @@
 }
 
 @if (toolbarTemplate(); as templateRef) {
-  <div class="anx-default-layout__toolbar anx-inline" data-anx-slot="toolbar">
+  <div class="anx-default-layout__toolbar" data-anx-slot="toolbar">
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   </div>
 }
@@ -14,7 +14,7 @@
   @switch (layoutVariant()) {
     @case ('grid') {
       <div
-        class="anx-default-layout__form-grid anx-grid"
+        class="anx-default-layout__form-grid"
         [style.--anx-layout-columns]="columnCount()"
       >
         @for (field of fields(); track fieldId(field, $index)) {
@@ -28,7 +28,7 @@
       </div>
     }
     @case ('inline') {
-      <div class="anx-default-layout__form-inline anx-inline">
+      <div class="anx-default-layout__form-inline">
         @for (field of fields(); track fieldId(field, $index)) {
           <ng-container
             *ngTemplateOutlet="
@@ -40,7 +40,7 @@
       </div>
     }
     @case ('card') {
-      <div class="anx-default-layout__form-card anx-stack">
+      <div class="anx-default-layout__form-card">
         @for (field of fields(); track fieldId(field, $index)) {
           <anarchitects-ui-card [appearance]="'outlined'">
             <ng-container
@@ -54,7 +54,7 @@
       </div>
     }
     @default {
-      <div class="anx-default-layout__form-stacked anx-stack">
+      <div class="anx-default-layout__form-stacked">
         @for (field of fields(); track fieldId(field, $index)) {
           <ng-container
             *ngTemplateOutlet="
@@ -78,7 +78,7 @@
   }
 }
 
-<div class="anx-default-layout__actions anx-inline" data-anx-slot="actions">
+<div class="anx-default-layout__actions" data-anx-slot="actions">
   @if (actionsTemplate(); as templateRef) {
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   } @else {

--- a/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.ts
+++ b/libs/common/angular/ui-layouts/defaults/src/form-layout-renderer.component.ts
@@ -26,7 +26,7 @@ import { resolveLayoutVariant, resolveTemplate } from './layout-renderer.utils';
   styleUrl: './form-layout-renderer.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-default-layout anx-default-layout--form anx-stack',
+    class: 'anx-default-layout anx-default-layout--form',
     '[attr.data-layout-variant]': 'layoutVariant()',
     'attr.data-anx-component': '"layout-form"',
   },

--- a/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.css
+++ b/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.css
@@ -1,11 +1,25 @@
 :host {
-  display: block;
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
 }
 
 .anx-default-layout__list,
 .anx-default-layout__list-grid,
 .anx-default-layout__list-card {
+  display: grid;
   gap: var(--anx-layout-gap-stack);
+}
+
+.anx-default-layout__toolbar,
+.anx-default-layout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--anx-layout-gap-inline);
+}
+
+.anx-default-layout__actions {
+  justify-content: flex-end;
 }
 
 .anx-default-layout__list {

--- a/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.html
+++ b/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.html
@@ -5,7 +5,7 @@
 }
 
 @if (toolbarTemplate(); as templateRef) {
-  <div class="anx-default-layout__toolbar anx-inline" data-anx-slot="toolbar">
+  <div class="anx-default-layout__toolbar" data-anx-slot="toolbar">
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   </div>
 }
@@ -14,7 +14,7 @@
   @switch (layoutVariant()) {
     @case ('grid') {
       <div
-        class="anx-default-layout__list-grid anx-grid"
+        class="anx-default-layout__list-grid"
         [style.--anx-layout-columns]="columnCount()"
       >
         @for (item of items(); track $index) {
@@ -30,7 +30,7 @@
       </div>
     }
     @case ('card') {
-      <div class="anx-default-layout__list-card anx-stack">
+      <div class="anx-default-layout__list-card">
         @for (item of items(); track $index) {
           <anarchitects-ui-card [appearance]="'outlined'">
             <ng-container
@@ -88,7 +88,7 @@
       </div>
     }
     @default {
-      <ul class="anx-default-layout__list anx-stack" role="list">
+      <ul class="anx-default-layout__list" role="list">
         @for (item of items(); track $index) {
           <li class="anx-default-layout__list-item" data-anx-slot="item">
             <ng-container
@@ -115,7 +115,7 @@
 }
 
 @if (actionsTemplate(); as templateRef) {
-  <div class="anx-default-layout__actions anx-inline" data-anx-slot="actions">
+  <div class="anx-default-layout__actions" data-anx-slot="actions">
     <ng-container *ngTemplateOutlet="templateRef"></ng-container>
   </div>
 }

--- a/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.ts
+++ b/libs/common/angular/ui-layouts/defaults/src/list-layout-renderer.component.ts
@@ -18,7 +18,7 @@ import { resolveLayoutVariant, resolveTemplate } from './layout-renderer.utils';
   styleUrl: './list-layout-renderer.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-default-layout anx-default-layout--list anx-stack',
+    class: 'anx-default-layout anx-default-layout--list',
     '[attr.data-layout-variant]': 'layoutVariant()',
     'attr.data-anx-component': '"layout-list"',
   },

--- a/libs/common/angular/ui-layouts/host/src/layout-host.component.css
+++ b/libs/common/angular/ui-layouts/host/src/layout-host.component.css
@@ -1,8 +1,12 @@
 :host {
-  display: block;
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
+  padding-block: var(--anx-layout-block-padding-current);
+  padding-inline: var(--anx-sys-space-lg);
 }
 
 .anx-layout-host__surface {
+  display: grid;
   padding: var(--anx-layout-block-padding-current);
   gap: var(--anx-layout-gap-stack);
 }

--- a/libs/common/angular/ui-layouts/host/src/layout-host.component.html
+++ b/libs/common/angular/ui-layouts/host/src/layout-host.component.html
@@ -1,5 +1,5 @@
 @if (resolvedLayout(); as resolved) {
-  <section class="anx-layout-host__surface anx-surface anx-stack">
+  <section class="anx-layout-host__surface anx-surface">
     <ng-container
       *ngComponentOutlet="
         resolved.definition.renderer;

--- a/libs/common/angular/ui-layouts/host/src/layout-host.component.ts
+++ b/libs/common/angular/ui-layouts/host/src/layout-host.component.ts
@@ -35,7 +35,7 @@ import { startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [AnxLayoutRegistryService],
   host: {
-    class: 'anx-layout-host anx-region anx-stack',
+    class: 'anx-layout-host',
     '[attr.data-anx-layout-kind]': 'kind()',
     '[attr.data-anx-layout-id]': 'resolvedLayout().definition.id',
     '[attr.data-anx-layout-source]': 'resolvedLayout().source',

--- a/libs/common/angular/ui-primitives/actions/src/button.css
+++ b/libs/common/angular/ui-primitives/actions/src/button.css
@@ -10,8 +10,11 @@
 }
 
 .anx-button__control {
+  display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
+  gap: var(--anx-layout-gap-inline);
   width: 100%;
   border-radius: var(--anx-cmp-button-radius);
   border: 1px solid var(--anx-cmp-button-border);

--- a/libs/common/angular/ui-primitives/actions/src/button.html
+++ b/libs/common/angular/ui-primitives/actions/src/button.html
@@ -1,5 +1,5 @@
 <button
-  class="anx-button__control anx-inline"
+  class="anx-button__control"
   [attr.type]="type()"
   [disabled]="disabled() || loading()"
   (click)="onClick($event)"

--- a/libs/common/angular/ui-primitives/feedback/src/alert.css
+++ b/libs/common/angular/ui-primitives/feedback/src/alert.css
@@ -48,6 +48,10 @@
 }
 
 .anx-alert__actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--anx-layout-gap-inline);
   margin-inline-start: auto;
 }
 

--- a/libs/common/angular/ui-primitives/feedback/src/alert.html
+++ b/libs/common/angular/ui-primitives/feedback/src/alert.html
@@ -9,7 +9,7 @@
   <ng-content></ng-content>
 </span>
 
-<span class="anx-alert__actions anx-inline" data-anx-slot="actions">
+<span class="anx-alert__actions" data-anx-slot="actions">
   <ng-content select="[anxSlot='actions'], [anxActions]"></ng-content>
 
   @if (dismissible()) {

--- a/libs/common/angular/ui-primitives/feedback/src/alert.ts
+++ b/libs/common/angular/ui-primitives/feedback/src/alert.ts
@@ -18,7 +18,7 @@ import {
   styleUrl: './alert.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-alert anx-inline',
+    class: 'anx-alert',
     '[attr.data-tone]': 'tone()',
     '[attr.data-appearance]': 'appearance()',
     '[attr.data-density]': 'density()',

--- a/libs/common/angular/ui-primitives/feedback/src/badge.ts
+++ b/libs/common/angular/ui-primitives/feedback/src/badge.ts
@@ -17,7 +17,7 @@ import {
   styleUrl: './badge.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-badge anx-inline',
+    class: 'anx-badge',
     '[attr.data-tone]': 'tone()',
     '[attr.data-appearance]': 'appearance()',
     '[attr.data-size]': 'size()',

--- a/libs/common/angular/ui-primitives/feedback/src/spinner.ts
+++ b/libs/common/angular/ui-primitives/feedback/src/spinner.ts
@@ -16,7 +16,7 @@ import {
   styleUrl: './spinner.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-spinner anx-inline',
+    class: 'anx-spinner',
     '[attr.data-size]': 'size()',
     '[attr.data-tone]': 'tone()',
     'attr.data-anx-component': '"spinner"',

--- a/libs/common/angular/ui-primitives/form-controls/src/field.css
+++ b/libs/common/angular/ui-primitives/form-controls/src/field.css
@@ -9,8 +9,11 @@
 }
 
 .anx-field__label-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: flex-start;
-  gap: var(--anx-sys-space-xs);
+  gap: var(--anx-layout-gap-inline);
 }
 
 .anx-field__label {
@@ -23,12 +26,15 @@
 }
 
 .anx-field__control-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   border: 1px solid var(--anx-cmp-field-border);
   border-radius: var(--anx-cmp-field-radius);
   background: var(--anx-cmp-field-bg);
   color: var(--anx-cmp-field-fg);
   padding-inline: var(--anx-sys-space-sm);
-  gap: var(--anx-sys-space-xs);
+  gap: var(--anx-layout-gap-inline);
 }
 
 .anx-field__control {

--- a/libs/common/angular/ui-primitives/form-controls/src/field.html
+++ b/libs/common/angular/ui-primitives/form-controls/src/field.html
@@ -1,4 +1,4 @@
-<div class="anx-field__label-row anx-inline" data-anx-slot="label">
+<div class="anx-field__label-row" data-anx-slot="label">
   <label class="anx-field__label" [attr.for]="forId()">
     <ng-content select="[anxSlot='label'], [anxLabel]"></ng-content>
   </label>
@@ -7,7 +7,7 @@
   }
 </div>
 
-<div class="anx-field__control-row anx-inline">
+<div class="anx-field__control-row">
   <span class="anx-field__slot anx-field__slot--start" data-anx-slot="start">
     <ng-content
       select="[anxSlot='start'], [anxSlot='prefix'], [anxStart]"

--- a/libs/common/angular/ui-primitives/form-controls/src/field.ts
+++ b/libs/common/angular/ui-primitives/form-controls/src/field.ts
@@ -16,7 +16,7 @@ let nextFieldId = 0;
   styleUrl: './field.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-field anx-stack',
+    class: 'anx-field',
     '[attr.data-density]': 'density()',
     '[attr.data-invalid]': 'invalid() ? "true" : null',
     '[attr.data-disabled]': 'disabled() ? "true" : null',

--- a/libs/common/angular/ui-primitives/surfaces/src/card.ts
+++ b/libs/common/angular/ui-primitives/surfaces/src/card.ts
@@ -16,7 +16,7 @@ import {
   styleUrl: './card.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'anx-card anx-surface anx-stack',
+    class: 'anx-card anx-surface',
     '[attr.data-appearance]': 'appearance()',
     '[attr.data-density]': 'density()',
     'attr.data-anx-component': '"card"',


### PR DESCRIPTION
- refactor ui-layouts host and default renderers (form/list/detail) to stop using shell-only utility classes (`anx-region`, `anx-stack`, `anx-inline`, `anx-grid`) in component host bindings
- migrate ui-layouts internal template wrappers away from shell utility classes and implement explicit layout behavior in component CSS (grid/flex/gap/padding)
- refactor ui-primitives hosts (`card`, `field`, `badge`, `spinner`, `alert`) to remove shell utility class usage
- remove remaining internal primitive template shell utility usage (`button`, `field`, `alert actions`) and replace with explicit CSS equivalents
- preserve existing rendering behavior and override points via existing CSS variables and data attributes
- keep Storybook consumer-context shell utility usage unchanged
- validate with focused lint/test runs:
  - `yarn nx run common-angular-ui-primitives:test --watch=false`
  - `yarn nx run common-angular-ui-layouts:test --watch=false`
  - `yarn nx run common-angular-ui-primitives:lint`
  - `yarn nx run common-angular-ui-layouts:lint`

Closes #221 Refs #204