### PR TITLE
docs(common-angular): harden shell/layout migration docs and README alignment

### DIFF
--- a/docs/guides/design-ui-systems.md
+++ b/docs/guides/design-ui-systems.md
@@ -40,7 +40,26 @@ Example:
 }
 ```
 
-## Package Author CSS Class Rules
+## Shell/Layout Contract Hardening (Phase 2)
+
+Shell and layout contracts are intentionally separated to prevent collisions.
+
+Source-of-truth symbols:
+
+- `ANX_SHELL_UTILITY_CLASSNAMES`
+- `ANX_DESIGN_HOOK_CLASSNAMES`
+- `ANX_SEMANTIC_CLASSNAMES` (backward-compatibility union)
+- `isAnxShellUtilityClass(...)`
+
+Package author rule source:
+
+- `ANX_PACKAGE_AUTHOR_RULES` in `@anarchitects/common-angular-design/styles`
+
+Enforcement source:
+
+- `tools/guardrails/shell-utility-collision.test.mjs`
+
+### Package Author CSS Class Rules
 
 When building UI package components, understand the two categories of semantic classes.
 
@@ -85,8 +104,7 @@ Use `:host` CSS for component-internal spacing instead:
 export class AnarchitectsCard {}
 ```
 
-For details, see the [CSS Class Rules](/contracts) in the contracts documentation and the
-migration target in [Phase 2: #221](https://github.com/anarchitects/anarchitecture-bricks-3tier/issues/221).
+For details, see the [CSS Class Rules](/contracts) in the contracts documentation.
 
 ## Single-Source Theme Setup
 
@@ -125,9 +143,6 @@ The provider applies `anx-root`, `data-anx-theme`, `data-anx-density`, and
 `data-anx-layout` and `data-anx-columns` remain explicit where local layout
 scope is required.
 
-For migrations from manual attributes, use the
-[Theme Migration Guide](/guides/theme-migration.html).
-
 ### Precedence Rules
 
 For managed root values (`theme`, `density`, `surface`) the resolution order is:
@@ -138,6 +153,23 @@ For managed root values (`theme`, `density`, `surface`) the resolution order is:
 
 This keeps migration safe because existing explicit attributes remain
 authoritative.
+
+## Migration and Validation Workflow
+
+When migrating existing consumers to hardened shell/layout contracts:
+
+1. Keep shell utility classes only in consumer shell wrappers.
+2. Remove shell utility classes from shared package component hosts and internal templates.
+3. Move component spacing to explicit component CSS (`:host`, component-scoped selectors).
+4. Validate contract enforcement and downstream behavior:
+   - `yarn nx run guardrails:test`
+   - `yarn nx run forms-angular-ui:test --testFile=libs/forms/angular/ui/src/form.spec.ts`
+5. Run docs verification:
+   - `yarn nx run docs-hub:validate-content`
+   - `yarn nx run docs-hub:build`
+   - `yarn nx run docs-hub:verify`
+
+For full migration sequence examples, see the [Theme Migration Guide](/guides/theme-migration.html).
 
 ## Composition Contracts
 
@@ -190,6 +222,8 @@ Use `@anarchitects/common-angular-ui-layouts` when runtime layout selection is r
   apply base styles first, then register provider config before rendering domain UI.
 - Pattern: product theming
   apply token/theme overrides in app shell, not shared packages.
+- Pattern: shell utility ownership
+  keep shell utility classes in consumer layout wrappers only.
 - Pattern: projection stability
   publish canonical slot/template names and avoid breaking renames.
 - Pattern: backend-safe evolution
@@ -203,6 +237,7 @@ Use `@anarchitects/common-angular-ui-layouts` when runtime layout selection is r
 - Hardcoding brand styles inside shared primitives.
 - Embedding orchestration/state logic in primitive components.
 - Breaking slot or template names without migration path.
+- Applying shell utility classes to shared package component hosts.
 - Shipping backend schema changes without OpenAPI and frontend consumer verification.
 
 ## Adoption Checklist
@@ -212,7 +247,10 @@ Use `@anarchitects/common-angular-ui-layouts` when runtime layout selection is r
 - Use `@anarchitects/common-angular-ui-primitives` as base visual building blocks.
 - Add `@anarchitects/common-angular-ui-layouts` only when runtime-selectable layout behavior is required.
 - Keep forms and auth frontend packages aligned with backend contracts (`@anarchitects/forms-angular`, `@anarchitects/auth-angular`, `@anarchitects/forms-nest`, `@anarchitects/auth-nest`).
-- Use [Theme Migration Guide](/guides/theme-migration.html) when moving existing apps away from manual root `data-anx-*` setup.
+- Keep shell utility classes in consumer layout wrappers and out of shared package hosts.
+- Validate guardrails and downstream integration:
+  `yarn nx run guardrails:test` and
+  `yarn nx run forms-angular-ui:test --testFile=libs/forms/angular/ui/src/form.spec.ts`.
 - Validate docs and generated outputs:
   `yarn nx run docs-hub:validate-content`,
   `yarn nx run docs-hub:build`,

--- a/docs/guides/theme-migration.md
+++ b/docs/guides/theme-migration.md
@@ -2,14 +2,16 @@
 
 ## Intent
 
-This guide explains how to migrate to a single-source theme setup for
-`@anarchitects/common-angular-design`.
+This guide explains how to migrate to a single-source design setup for
+`@anarchitects/common-angular-design`, including shell/layout collision
+prevention introduced in the Phase 2 hardening.
 
-Goal:
+Goals:
 
 - Keep one canonical setup path for new apps.
 - Migrate existing apps away from manual root `data-anx-*` attributes safely.
 - Preserve backward compatibility during rollout.
+- Prevent shell utility class collisions across shared package internals.
 
 ## Canonical Setup
 
@@ -40,17 +42,12 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
-## Before and After
+## Theme Before and After
 
 Before (manual root attributes):
 
 ```html
-<html
-  class="anx-root"
-  data-anx-theme="ocean"
-  data-anx-density="compact"
-  data-anx-surface="card"
->
+<html class="anx-root" data-anx-theme="ocean" data-anx-density="compact" data-anx-surface="card">
   ...
 </html>
 ```
@@ -90,12 +87,83 @@ Backward compatibility is intentionally preserved:
 - Explicit manual attributes stay authoritative over provider defaults.
 - Mixed mode is valid during migration windows.
 
+## Shell Utility Collision Migration (Phase 2)
+
+Shell utility classes are consumer shell layout classes only:
+
+- `anx-region`
+- `anx-stack`
+- `anx-inline`
+- `anx-grid`
+
+Shared package internals (`ui-layouts`, `ui-primitives`) must not rely on these
+classes for component host spacing.
+
+### Migration Objective
+
+Move shared component spacing to explicit component CSS and keep shell utility
+usage in app shell wrappers.
+
+### Before (collision-prone package host usage)
+
+```ts
+@Component({
+  host: {
+    class: 'anx-default-layout anx-stack',
+  },
+})
+export class DefaultLayoutComponent {}
+```
+
+### After (contract-safe package host usage)
+
+```ts
+@Component({
+  host: {
+    class: 'anx-default-layout',
+  },
+  styles: `
+    :host {
+      display: grid;
+      gap: var(--anx-layout-gap-stack);
+      padding: var(--anx-layout-block-padding-current);
+    }
+  `,
+})
+export class DefaultLayoutComponent {}
+```
+
+### Consumer Shell Usage (still valid)
+
+```html
+<section class="anx-region anx-stack" data-anx-layout="grid">
+  <anarchitects-forms-ui-form></anarchitects-forms-ui-form>
+</section>
+```
+
 ## Recommended Migration Sequence
 
-1. Add provider setup in bootstrap and keep existing manual attributes.
+1. Add provider setup in bootstrap and keep existing manual root attributes.
 2. Verify runtime output still matches expected theme context.
 3. Remove manual root `data-anx-*` attributes when provider values are verified.
-4. Keep explicit manual attributes only where deliberate overrides are required.
+4. Audit shared package hosts and templates for shell utility class usage.
+5. Replace package-internal shell utility usage with explicit component CSS.
+6. Keep shell utility classes in consumer wrappers only.
+
+## Validation Checklist
+
+Run both contract and downstream checks:
+
+1. `yarn nx run guardrails:test`
+2. `yarn nx run forms-angular-ui:test --testFile=libs/forms/angular/ui/src/form.spec.ts`
+3. `yarn nx run docs-hub:validate-content`
+4. `yarn nx run docs-hub:build`
+5. `yarn nx run docs-hub:verify`
+
+Evidence references:
+
+- Guardrail enforcement: `tools/guardrails/shell-utility-collision.test.mjs`
+- Downstream regression coverage: `libs/forms/angular/ui/src/form.spec.ts`
 
 ## Storybook Note
 

--- a/libs/common/angular/design/README.md
+++ b/libs/common/angular/design/README.md
@@ -2,9 +2,9 @@
 
 Reusable Angular design foundations for Anarchitecture bricks.
 
-This package provides the **Phase 1 design contract**: tokens, semantic hook conventions,
-base scoped styles, and typed configuration providers. It is intentionally unbranded and
-extensible for consumer applications.
+This package provides the design contract foundation: tokens, semantic hook
+conventions, base scoped styles, and typed configuration providers. It is
+intentionally unbranded and extensible for consumer applications.
 
 ## Features
 
@@ -12,6 +12,7 @@ extensible for consumer applications.
 - Explicit root-host directive for syncing theme, density, and surface to DOM attributes
 - Shared semantic token contracts for cross-library visual consistency
 - Base styles and semantic hooks designed for consumer override
+- Package-author rules for shell utility class boundaries
 
 ## Installation
 
@@ -30,7 +31,24 @@ yarn add @anarchitects/common-angular-design
 - `@anarchitects/common-angular-design/contracts`
   - Stable data-attribute and semantic-class contracts
 - `@anarchitects/common-angular-design/styles`
-  - Base stylesheet contract and import conventions
+  - Base stylesheet contract and package-author class rules
+
+## Shell Utility Class Contract
+
+Source-of-truth symbols in `contracts`:
+
+- `ANX_SHELL_UTILITY_CLASSNAMES`
+- `ANX_DESIGN_HOOK_CLASSNAMES`
+- `ANX_SEMANTIC_CLASSNAMES` (backward-compatible union)
+- `isAnxShellUtilityClass(...)`
+
+Package-author rule in `styles`:
+
+- `ANX_PACKAGE_AUTHOR_RULES.forbiddenOnComponentHost`
+
+Shell utility classes (`anx-region`, `anx-stack`, `anx-inline`, `anx-grid`) are
+consumer shell layout classes and must not be applied to shared package
+component hosts. Use explicit `:host` CSS for component-internal spacing.
 
 ## Consumer extensibility model
 
@@ -70,22 +88,21 @@ export const appConfig = {
 };
 ```
 
-### 3) Render content without a required manual root host
+### 3) Keep shell classes in consumer wrappers
 
 ```html
-<section data-anx-layout="list" data-anx-columns="1">
-  <div class="anx-region anx-stack">
-    <h2 class="anx-heading">Contact</h2>
-    <p class="anx-text">A neutral foundation, ready for consumer theming.</p>
-  </div>
+<section class="anx-region anx-stack" data-anx-layout="list" data-anx-columns="1">
+  <h2 class="anx-heading">Contact</h2>
+  <p class="anx-text">A neutral foundation, ready for consumer theming.</p>
 </section>
 ```
 
-`provideDesignSystemConfig(...)` now applies `anx-root`,
-`data-anx-theme`, `data-anx-density`, and `data-anx-surface` to
-`document.documentElement` automatically during bootstrap.
-`data-anx-layout` and `data-anx-columns` remain explicit where layout scoping is
-needed.
+`provideDesignSystemConfig(...)` applies `anx-root`, `data-anx-theme`,
+`data-anx-density`, and `data-anx-surface` to `document.documentElement`
+automatically during bootstrap.
+
+`data-anx-layout` and `data-anx-columns` remain explicit where local layout
+scoping is needed.
 
 Use `anarchitectsDesignRoot` only when a subtree needs explicit local theme,
 density, or surface overrides.
@@ -94,18 +111,26 @@ Existing apps can keep manual `data-anx-theme`, `data-anx-density`, and
 `data-anx-surface` attributes during migration. Explicit manual attributes stay
 authoritative over provider-derived defaults.
 
-For migration steps and before/after examples, see
-`docs/guides/theme-migration.md`.
-
 ## Usage
 
-Use this package as the design contract foundation in app bootstrap, then layer `ui-primitives`, `ui-composition`, and domain UI libraries on top of the same token/context model.
+Use this package as the root design contract for shared Angular UI libraries.
+Apply base styles once, configure provider defaults at app bootstrap, and keep
+shell utility classes in consumer wrappers rather than shared package hosts.
 
-## Phase 1 boundaries
+## Validation workflow
 
-- No integration into existing `forms` or `auth` Angular UI yet
-- No primitive catalog rollout yet
-- No full layout engine yet
+For shell/layout contract migration checks:
+
+1. `yarn nx run guardrails:test`
+2. `yarn nx run forms-angular-ui:test --testFile=libs/forms/angular/ui/src/form.spec.ts`
+3. `yarn nx run docs-hub:validate-content`
+4. `yarn nx run docs-hub:build`
+5. `yarn nx run docs-hub:verify`
+
+## Documentation
+
+- System guide: `docs/guides/design-ui-systems.md`
+- Migration guide: `docs/guides/theme-migration.md`
 
 ## Development notes
 

--- a/libs/common/angular/ui-layouts/README.md
+++ b/libs/common/angular/ui-layouts/README.md
@@ -2,15 +2,16 @@
 
 Pluggable layout runtime infrastructure for Angular bricks.
 
-This package provides the Phase 3 layout system contracts, registry,
-runtime host, and built-in default layouts. It is shared infrastructure
-only and does not migrate domain `forms`/`auth` components in this phase.
+This package provides layout contracts, registry, runtime host, and built-in
+default layouts. It is shared infrastructure only and does not embed
+domain-specific behavior.
 
 ## Features
 
 - Layout contracts and runtime host components for pluggable rendering
 - Registry-based layout resolution with explicit defaults
 - Default implementations for form/list/detail layout kinds
+- Contract-safe host styling aligned with shell utility collision prevention
 
 ## Installation
 
@@ -39,6 +40,34 @@ yarn add @anarchitects/common-angular-ui-layouts
 2. provider default from `ANX_LAYOUT_DEFAULTS[kind]`
 3. built-in fallback for the kind
 
+## Shell Utility Boundary
+
+Shell utility classes (`anx-region`, `anx-stack`, `anx-inline`, `anx-grid`) are
+consumer shell layout classes and must not be used by package host bindings or
+internal templates.
+
+Use explicit component CSS for spacing and flow in layout renderers.
+
+Incorrect:
+
+```ts
+host: { class: 'anx-default-layout anx-stack' }
+```
+
+Correct:
+
+```ts
+host: { class: 'anx-default-layout' }
+```
+
+```css
+:host {
+  display: grid;
+  gap: var(--anx-layout-gap-stack);
+  padding: var(--anx-layout-block-padding-current);
+}
+```
+
 ## Consumer extension
 
 Consumer apps can add layouts without modifying core by:
@@ -49,7 +78,21 @@ Consumer apps can add layouts without modifying core by:
 
 ## Usage
 
-Use this package when you need runtime-selectable layouts with deterministic fallback behavior across UI feature surfaces.
+Use this package when runtime-selectable layout behavior is required. Keep
+layout resolution in shared infrastructure and keep shell utility class usage in
+consumer route/page wrappers.
+
+## Validation workflow
+
+Contract and downstream validation references:
+
+1. `yarn nx run guardrails:test`
+2. `yarn nx run forms-angular-ui:test --testFile=libs/forms/angular/ui/src/form.spec.ts`
+
+## Documentation
+
+- System guide: `docs/guides/design-ui-systems.md`
+- Migration guide: `docs/guides/theme-migration.md`
 
 ## Development notes
 


### PR DESCRIPTION
document Phase 2 shell/layout contract hardening and class ownership rules
add explicit migration + validation workflow (guardrails, downstream tests, docs checks)
align package READMEs with docs-hub structure/Usage requirements
clarify adoption checklist and package-author guidance
Closes #223
Refs #204