### PR TITLE
feat(auth-angular): derive auth form config from injected contracts

### DIFF
--- a/libs/auth/angular/config/src/providers.spec.ts
+++ b/libs/auth/angular/config/src/providers.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { provideAuthConfig, provideAuthDefaults } from './providers';
-import { API_RESOURCE_PATH, AUTH_CONFIG } from './tokens';
+import {
+  provideAuthConfig,
+  provideAuthContracts,
+  provideAuthDefaults,
+} from './providers';
+import { API_RESOURCE_PATH, AUTH_CONFIG, AUTH_CONTRACTS } from './tokens';
 
 describe('AuthConfig Providers', () => {
   afterEach(() => {
@@ -25,5 +29,44 @@ describe('AuthConfig Providers', () => {
     const apiResourcePath = TestBed.inject(API_RESOURCE_PATH);
     expect(config.apiResourcePath).toBe('custom-auth-path');
     expect(apiResourcePath).toBe('custom-auth-path');
+  });
+
+  it('should provide default auth contracts when no overrides are supplied', () => {
+    TestBed.configureTestingModule({
+      providers: [...provideAuthContracts()],
+    });
+
+    const contracts = TestBed.inject(AUTH_CONTRACTS);
+
+    expect(contracts.registerFormMeta.name.required).toBe(false);
+    expect(contracts.loginFormMeta.password.minLength).toBe(6);
+  });
+
+  it('should merge nested auth contract overrides deterministically', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        ...provideAuthContracts({
+          register: {
+            name: {
+              required: true,
+              minLength: 3,
+            },
+          },
+          login: {
+            password: {
+              minLength: 10,
+            },
+          },
+        }),
+      ],
+    });
+
+    const contracts = TestBed.inject(AUTH_CONTRACTS);
+
+    expect(contracts.registerFormMeta.name.required).toBe(true);
+    expect(contracts.registerFormMeta.name.minLength).toBe(3);
+    expect(contracts.registerFormMeta.name.maxLength).toBe(100);
+    expect(contracts.loginFormMeta.password.minLength).toBe(10);
+    expect(contracts.loginFormMeta.credential.minLength).toBe(2);
   });
 });

--- a/libs/auth/angular/config/src/providers.ts
+++ b/libs/auth/angular/config/src/providers.ts
@@ -1,9 +1,20 @@
 import { Provider } from '@angular/core';
+import type {
+  AuthContractConfig,
+  AuthFieldConfig,
+} from '@anarchitects/auth-ts';
+import {
+  DefaultAuthContractConfig,
+  createAuthContracts,
+} from '@anarchitects/auth-ts';
 import {
   API_RESOURCE_PATH,
+  AUTH_CONTRACTS,
   AUTH_CONFIG,
   AUTH_DEFAULTS,
   AuthConfig,
+  AuthFieldConfigOverrides,
+  AuthContractConfigOverrides,
 } from './tokens';
 
 export function provideAuthConfig(cfg: Partial<AuthConfig>): Provider[] {
@@ -27,4 +38,117 @@ export function provideAuthConfig(cfg: Partial<AuthConfig>): Provider[] {
 
 export function provideAuthDefaults(): Provider[] {
   return provideAuthConfig({});
+}
+
+const hasOwn = <K extends PropertyKey>(
+  value: object | undefined,
+  key: K,
+): value is Record<K, unknown> =>
+  value !== undefined && Object.prototype.hasOwnProperty.call(value, key);
+
+const resolveAuthFieldConfig = (
+  defaults: AuthFieldConfig,
+  overrides?: AuthFieldConfigOverrides,
+): AuthFieldConfig => {
+  const fieldOverrides = overrides;
+
+  return {
+    required: fieldOverrides?.required ?? defaults.required,
+    minLength: hasOwn(fieldOverrides, 'minLength')
+      ? fieldOverrides.minLength
+      : defaults.minLength,
+    maxLength: hasOwn(fieldOverrides, 'maxLength')
+      ? fieldOverrides.maxLength
+      : defaults.maxLength,
+    emptyStringPolicy:
+      fieldOverrides?.emptyStringPolicy ?? defaults.emptyStringPolicy,
+  };
+};
+
+const resolveAuthContractConfig = (
+  overrides: AuthContractConfigOverrides = {},
+): AuthContractConfig => ({
+  version: overrides.version ?? DefaultAuthContractConfig.version,
+  register: {
+    email: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.register.email,
+      overrides.register?.email,
+    ),
+    password: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.register.password,
+      overrides.register?.password,
+    ),
+    confirmPassword: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.register.confirmPassword,
+      overrides.register?.confirmPassword,
+    ),
+    name: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.register.name,
+      overrides.register?.name,
+    ),
+  },
+  login: {
+    credential: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.login.credential,
+      overrides.login?.credential,
+    ),
+    password: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.login.password,
+      overrides.login?.password,
+    ),
+  },
+  forgotPassword: {
+    email: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.forgotPassword.email,
+      overrides.forgotPassword?.email,
+    ),
+  },
+  resetPassword: {
+    token: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.resetPassword.token,
+      overrides.resetPassword?.token,
+    ),
+    password: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.resetPassword.password,
+      overrides.resetPassword?.password,
+    ),
+    confirmPassword: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.resetPassword.confirmPassword,
+      overrides.resetPassword?.confirmPassword,
+    ),
+  },
+  verifyEmail: {
+    token: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.verifyEmail.token,
+      overrides.verifyEmail?.token,
+    ),
+  },
+  changePassword: {
+    currentPassword: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.changePassword.currentPassword,
+      overrides.changePassword?.currentPassword,
+    ),
+    newPassword: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.changePassword.newPassword,
+      overrides.changePassword?.newPassword,
+    ),
+    confirmPassword: resolveAuthFieldConfig(
+      DefaultAuthContractConfig.changePassword.confirmPassword,
+      overrides.changePassword?.confirmPassword,
+    ),
+  },
+  logout: {},
+});
+
+export function provideAuthContracts(
+  overrides: AuthContractConfigOverrides = {},
+): Provider[] {
+  const resolvedConfig = resolveAuthContractConfig(overrides);
+
+  return [
+    {
+      provide: AUTH_CONTRACTS,
+      useValue: createAuthContracts(resolvedConfig),
+    },
+  ];
 }

--- a/libs/auth/angular/config/src/tokens.spec.ts
+++ b/libs/auth/angular/config/src/tokens.spec.ts
@@ -1,12 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 import {
+  DefaultAuthContractConfig,
+  createAuthContracts,
+} from '@anarchitects/auth-ts';
+import {
+  AUTH_CONTRACTS,
   AUTH_CONFIG,
   AUTH_DEFAULTS,
   AuthConfig,
+  injectAuthContracts,
   injectAuthConfig,
 } from './tokens';
 
 describe('AuthConfig', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
   it('should provide default values', () => {
     TestBed.configureTestingModule({
       providers: [{ provide: AUTH_CONFIG, useValue: AUTH_DEFAULTS }],
@@ -37,6 +47,40 @@ describe('AuthConfig', () => {
     TestBed.runInInjectionContext(() => {
       const config = TestBed.inject<AuthConfig>(AUTH_CONFIG);
       expect(config).toEqual(customConfig);
+    });
+  });
+
+  it('should inject default auth contracts when no provider is registered', () => {
+    TestBed.runInInjectionContext(() => {
+      const contracts = injectAuthContracts();
+
+      expect(contracts.registerFormMeta.name.required).toBe(
+        DefaultAuthContractConfig.register.name.required,
+      );
+      expect(contracts.loginFormMeta.password.minLength).toBe(
+        DefaultAuthContractConfig.login.password.minLength,
+      );
+    });
+  });
+
+  it('should expose provided auth contracts overrides', () => {
+    const contracts = createAuthContracts({
+      ...DefaultAuthContractConfig,
+      register: {
+        ...DefaultAuthContractConfig.register,
+        name: {
+          ...DefaultAuthContractConfig.register.name,
+          required: true,
+        },
+      },
+    });
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: AUTH_CONTRACTS, useValue: contracts }],
+    });
+
+    TestBed.runInInjectionContext(() => {
+      expect(injectAuthContracts()).toBe(contracts);
     });
   });
 });

--- a/libs/auth/angular/config/src/tokens.ts
+++ b/libs/auth/angular/config/src/tokens.ts
@@ -1,5 +1,18 @@
 import { HttpContextToken } from '@angular/common/http';
 import { InjectionToken, inject } from '@angular/core';
+import {
+  type AuthContractConfig,
+  type AuthContracts,
+  type AuthFieldConfig,
+  type ChangePasswordFieldConfig,
+  DefaultAuthContractConfig,
+  type ForgotPasswordFieldConfig,
+  type LoginFieldConfig,
+  type RegisterFieldConfig,
+  type ResetPasswordFieldConfig,
+  type VerifyEmailFieldConfig,
+  createAuthContracts,
+} from '@anarchitects/auth-ts';
 
 export type AuthConfig = {
   apiResourcePath: string;
@@ -12,10 +25,43 @@ export type AuthConfig = {
 
 export const AUTH_CONFIG = new InjectionToken<AuthConfig>('AUTH_CONFIG');
 export const API_RESOURCE_PATH = new InjectionToken<string>(
-  'AUTH_API_RESOURCE_PATH'
+  'AUTH_API_RESOURCE_PATH',
 );
 export const SUPPRESS_AUTH_FAILURE_REDIRECT = new HttpContextToken<boolean>(
   () => false,
+);
+
+export type AuthFieldConfigOverrides = Partial<AuthFieldConfig>;
+
+export type AuthContractConfigOverrides = {
+  version?: AuthContractConfig['version'];
+  register?: Partial<{
+    [K in keyof RegisterFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+  login?: Partial<{
+    [K in keyof LoginFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+  forgotPassword?: Partial<{
+    [K in keyof ForgotPasswordFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+  resetPassword?: Partial<{
+    [K in keyof ResetPasswordFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+  verifyEmail?: Partial<{
+    [K in keyof VerifyEmailFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+  changePassword?: Partial<{
+    [K in keyof ChangePasswordFieldConfig]: AuthFieldConfigOverrides;
+  }>;
+};
+export type ResolvedAuthContracts = AuthContracts<AuthContractConfig>;
+
+export const AUTH_CONTRACTS = new InjectionToken<ResolvedAuthContracts>(
+  'AUTH_CONTRACTS',
+  {
+    factory: () =>
+      createAuthContracts(DefaultAuthContractConfig) as ResolvedAuthContracts,
+  },
 );
 
 /** Library-level sensible defaults */
@@ -38,4 +84,8 @@ export function injectApiResourcePath(): string {
     inject(API_RESOURCE_PATH, { optional: true }) ??
     AUTH_DEFAULTS.apiResourcePath
   );
+}
+
+export function injectAuthContracts(): ResolvedAuthContracts {
+  return inject(AUTH_CONTRACTS);
 }

--- a/libs/auth/angular/ui/src/components/activate-user-form/activate-user-form.ts
+++ b/libs/auth/angular/ui/src/components/activate-user-form/activate-user-form.ts
@@ -29,11 +29,13 @@ export class AnarchitectsAuthUiActivateUserForm {
   readonly submitted = output<ActivateUserRequestDTO>();
 
   readonly formConfig = computed(() =>
-    activateUserFormBridge.resolveFormConfig({ token: this.token() }),
+    activateUserFormBridge.resolveFormConfig(undefined, {
+      token: this.token(),
+    }),
   );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = activateUserFormBridge.mapSubmission(input, {
+    const dto = activateUserFormBridge.mapSubmission(input, undefined, {
       token: this.token(),
     });
     if (dto) {

--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
@@ -1,4 +1,6 @@
+import { Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { ChangePasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiChangePasswordForm } from './change-password-form';
@@ -7,14 +9,20 @@ describe('AnarchitectsAuthUiChangePasswordForm', () => {
   let component: AnarchitectsAuthUiChangePasswordForm;
   let fixture: ComponentFixture<AnarchitectsAuthUiChangePasswordForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiChangePasswordForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiChangePasswordForm);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
   });
 
   it('should configure confirmPassword to match newPassword', () => {
@@ -26,6 +34,32 @@ describe('AnarchitectsAuthUiChangePasswordForm', () => {
         message: 'Passwords must match.',
       },
     ]);
+  });
+
+  it('should read contract-driven password metadata', async () => {
+    await setup(
+      provideAuthContracts({
+        changePassword: {
+          confirmPassword: {
+            required: false,
+          },
+          newPassword: {
+            minLength: 10,
+          },
+        },
+      }),
+    );
+
+    expect(
+      component
+        .formConfig()
+        .fields.find((field) => field.name === 'confirmPassword')?.required,
+    ).toBe(false);
+    expect(
+      component
+        .formConfig()
+        .fields.find((field) => field.name === 'newPassword')?.minLength,
+    ).toBe(10);
   });
 
   it('should map submission payload to ChangePasswordRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.ts
@@ -1,4 +1,5 @@
 import { ChangePasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,16 +24,21 @@ import { changePasswordFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiChangePasswordForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ChangePasswordRequestDTO>();
 
   readonly formConfig = computed(() =>
-    changePasswordFormBridge.resolveFormConfig(),
+    changePasswordFormBridge.resolveFormConfig(this.authContracts),
   );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = changePasswordFormBridge.mapSubmission(input);
+    const dto = changePasswordFormBridge.mapSubmission(
+      input,
+      this.authContracts,
+    );
     if (dto) {
       this.submitted.emit(dto);
     }

--- a/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.spec.ts
@@ -1,4 +1,6 @@
+import { Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { ForgotPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiForgotPasswordForm } from './forgot-password-form';
@@ -7,14 +9,34 @@ describe('AnarchitectsAuthUiForgotPasswordForm', () => {
   let component: AnarchitectsAuthUiForgotPasswordForm;
   let fixture: ComponentFixture<AnarchitectsAuthUiForgotPasswordForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiForgotPasswordForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiForgotPasswordForm);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  it('should read contract-driven email required metadata', async () => {
+    await setup(
+      provideAuthContracts({
+        forgotPassword: {
+          email: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    expect(component.formConfig().fields[0]?.required).toBe(false);
   });
 
   it('should map submission payload to ForgotPasswordRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.ts
+++ b/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.ts
@@ -1,4 +1,5 @@
 import { ForgotPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,16 +24,21 @@ import { forgotPasswordFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiForgotPasswordForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ForgotPasswordRequestDTO>();
 
   readonly formConfig = computed(() =>
-    forgotPasswordFormBridge.resolveFormConfig(),
+    forgotPasswordFormBridge.resolveFormConfig(this.authContracts),
   );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = forgotPasswordFormBridge.mapSubmission(input);
+    const dto = forgotPasswordFormBridge.mapSubmission(
+      input,
+      this.authContracts,
+    );
     if (dto) {
       this.submitted.emit(dto);
     }

--- a/libs/auth/angular/ui/src/components/login-form/login-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/login-form/login-form.spec.ts
@@ -1,4 +1,6 @@
+import { Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { LoginRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiLoginForm } from './login-form';
@@ -7,14 +9,20 @@ describe('AnarchitectsAuthUiLoginForm', () => {
   let component: AnarchitectsAuthUiLoginForm;
   let fixture: ComponentFixture<AnarchitectsAuthUiLoginForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiLoginForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiLoginForm);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
   });
 
   it('should create', () => {
@@ -24,6 +32,23 @@ describe('AnarchitectsAuthUiLoginForm', () => {
   it('should expose login form config', () => {
     expect(component.formConfig().id).toBe('login');
     expect(component.formConfig().fields).toHaveLength(2);
+  });
+
+  it('should read contract-driven password minLength', async () => {
+    await setup(
+      provideAuthContracts({
+        login: {
+          password: {
+            minLength: 10,
+          },
+        },
+      }),
+    );
+
+    expect(
+      component.formConfig().fields.find((field) => field.name === 'password')
+        ?.minLength,
+    ).toBe(10);
   });
 
   it('should map submission payload to LoginRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/login-form/login-form.ts
+++ b/libs/auth/angular/ui/src/components/login-form/login-form.ts
@@ -1,4 +1,5 @@
 import { LoginRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,14 +24,18 @@ import { loginFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiLoginForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<LoginRequestDTO>();
 
-  readonly formConfig = computed(() => loginFormBridge.resolveFormConfig());
+  readonly formConfig = computed(() =>
+    loginFormBridge.resolveFormConfig(this.authContracts),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = loginFormBridge.mapSubmission(input);
+    const dto = loginFormBridge.mapSubmission(input, this.authContracts);
     if (dto) {
       this.submitted.emit(dto);
     }

--- a/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
@@ -1,4 +1,6 @@
+import { Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { RegisterRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiRegisterForm } from './register-form';
@@ -7,14 +9,20 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
   let component: AnarchitectsAuthUiRegisterForm;
   let fixture: ComponentFixture<AnarchitectsAuthUiRegisterForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiRegisterForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiRegisterForm);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
   });
 
   it('should create', () => {
@@ -30,6 +38,23 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
         message: 'Passwords must match.',
       },
     ]);
+  });
+
+  it('should read contract-driven required metadata for name', async () => {
+    await setup(
+      provideAuthContracts({
+        register: {
+          name: {
+            required: true,
+          },
+        },
+      }),
+    );
+
+    expect(
+      component.formConfig().fields.find((field) => field.name === 'name')
+        ?.required,
+    ).toBe(true);
   });
 
   it('should map submission payload to RegisterRequestDTO', () => {
@@ -86,20 +111,29 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
     expect(confirmPasswordInput).toBeTruthy();
     expect(submitButton).toBeTruthy();
 
-    emailInput!.value = 'jane@example.com';
-    emailInput!.dispatchEvent(new Event('input'));
-    passwordInput!.value = 'secret123';
-    passwordInput!.dispatchEvent(new Event('input'));
-    confirmPasswordInput!.value = 'secret124';
-    confirmPasswordInput!.dispatchEvent(new Event('input'));
-    confirmPasswordInput!.dispatchEvent(new Event('blur'));
+    if (
+      !emailInput ||
+      !passwordInput ||
+      !confirmPasswordInput ||
+      !submitButton
+    ) {
+      throw new Error('Expected register form inputs to be rendered.');
+    }
+
+    emailInput.value = 'jane@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret124';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.dispatchEvent(new Event('blur'));
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(submitButton?.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(true);
     expect(nativeElement.textContent).toContain('Passwords must match.');
 
-    submitButton?.click();
+    submitButton.click();
     fixture.detectChanges();
 
     expect(emitted).toBeUndefined();

--- a/libs/auth/angular/ui/src/components/register-form/register-form.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.ts
@@ -1,4 +1,5 @@
 import { RegisterRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,14 +24,18 @@ import { registerFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiRegisterForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<RegisterRequestDTO>();
 
-  readonly formConfig = computed(() => registerFormBridge.resolveFormConfig());
+  readonly formConfig = computed(() =>
+    registerFormBridge.resolveFormConfig(this.authContracts),
+  );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = registerFormBridge.mapSubmission(input);
+    const dto = registerFormBridge.mapSubmission(input, this.authContracts);
     if (dto) {
       this.submitted.emit(dto);
     }

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
@@ -1,5 +1,6 @@
+import { ComponentRef, Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ComponentRef } from '@angular/core';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { ResetPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiResetPasswordForm } from './reset-password-form';
@@ -9,15 +10,21 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
   let fixture: ComponentFixture<AnarchitectsAuthUiResetPasswordForm>;
   let ref: ComponentRef<AnarchitectsAuthUiResetPasswordForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiResetPasswordForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiResetPasswordForm);
     component = fixture.componentInstance;
     ref = fixture.componentRef;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
   });
 
   it('should configure confirmPassword to match password', () => {
@@ -29,6 +36,23 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
         message: 'Passwords must match.',
       },
     ]);
+  });
+
+  it('should read contract-driven token minLength', async () => {
+    await setup(
+      provideAuthContracts({
+        resetPassword: {
+          token: {
+            minLength: 8,
+          },
+        },
+      }),
+    );
+
+    expect(
+      component.formConfig().fields.find((field) => field.name === 'token')
+        ?.minLength,
+    ).toBe(8);
   });
 
   it('should map payload token and password fields', () => {
@@ -77,5 +101,15 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
     component.onSubmitted(submission);
 
     expect(emitted?.token).toBe('prefilled-token');
+  });
+
+  it('should keep the token field optional in UI when a token input is prefilled', () => {
+    ref.setInput('token', 'prefilled-token');
+    fixture.detectChanges();
+
+    expect(
+      component.formConfig().fields.find((field) => field.name === 'token')
+        ?.required,
+    ).toBe(false);
   });
 });

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.ts
@@ -1,4 +1,5 @@
 import { ResetPasswordRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,19 +24,27 @@ import { resetPasswordFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiResetPasswordForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly token = input<string>();
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<ResetPasswordRequestDTO>();
 
   readonly formConfig = computed(() =>
-    resetPasswordFormBridge.resolveFormConfig({ token: this.token() }),
+    resetPasswordFormBridge.resolveFormConfig(this.authContracts, {
+      token: this.token(),
+    }),
   );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = resetPasswordFormBridge.mapSubmission(input, {
-      token: this.token(),
-    });
+    const dto = resetPasswordFormBridge.mapSubmission(
+      input,
+      this.authContracts,
+      {
+        token: this.token(),
+      },
+    );
     if (dto) {
       this.submitted.emit(dto);
     }

--- a/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.spec.ts
@@ -1,5 +1,6 @@
+import { ComponentRef, Provider } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ComponentRef } from '@angular/core';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { VerifyEmailRequestDTO } from '@anarchitects/auth-ts/dtos';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import { AnarchitectsAuthUiVerifyEmailForm } from './verify-email-form';
@@ -9,15 +10,35 @@ describe('AnarchitectsAuthUiVerifyEmailForm', () => {
   let fixture: ComponentFixture<AnarchitectsAuthUiVerifyEmailForm>;
   let ref: ComponentRef<AnarchitectsAuthUiVerifyEmailForm>;
 
-  beforeEach(async () => {
+  const setup = async (providers: Provider[] = []) => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [AnarchitectsAuthUiVerifyEmailForm],
+      providers,
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnarchitectsAuthUiVerifyEmailForm);
     component = fixture.componentInstance;
     ref = fixture.componentRef;
     await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  it('should read contract-driven token minLength', async () => {
+    await setup(
+      provideAuthContracts({
+        verifyEmail: {
+          token: {
+            minLength: 8,
+          },
+        },
+      }),
+    );
+
+    expect(component.formConfig().fields[0]?.minLength).toBe(8);
   });
 
   it('should use token input fallback when payload token is missing', () => {
@@ -38,6 +59,13 @@ describe('AnarchitectsAuthUiVerifyEmailForm', () => {
     component.onSubmitted(submission);
 
     expect(emitted).toEqual({ token: 'prefilled-token' });
+  });
+
+  it('should keep the token field optional in UI when a token input is prefilled', () => {
+    ref.setInput('token', 'prefilled-token');
+    fixture.detectChanges();
+
+    expect(component.formConfig().fields[0]?.required).toBe(false);
   });
 
   it('should not emit when token cannot be resolved', () => {

--- a/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.ts
+++ b/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.ts
@@ -1,4 +1,5 @@
 import { VerifyEmailRequestDTO } from '@anarchitects/auth-ts/dtos';
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AnarchitectsUiForm } from '@anarchitects/forms-angular/ui';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
 import {
@@ -23,17 +24,21 @@ import { verifyEmailFormBridge } from '../../internal/auth-form-bridges';
   },
 })
 export class AnarchitectsAuthUiVerifyEmailForm {
+  private readonly authContracts = injectAuthContracts();
+
   readonly token = input<string>();
   readonly layout = input<AnxLayoutId | null>(null);
   readonly layoutOptions = input<Readonly<Record<string, unknown>>>({});
   readonly submitted = output<VerifyEmailRequestDTO>();
 
   readonly formConfig = computed(() =>
-    verifyEmailFormBridge.resolveFormConfig({ token: this.token() }),
+    verifyEmailFormBridge.resolveFormConfig(this.authContracts, {
+      token: this.token(),
+    }),
   );
 
   onSubmitted(input: SubmissionRequestDTO): void {
-    const dto = verifyEmailFormBridge.mapSubmission(input, {
+    const dto = verifyEmailFormBridge.mapSubmission(input, this.authContracts, {
       token: this.token(),
     });
     if (dto) {

--- a/libs/auth/angular/ui/src/internal/auth-form-bridges.ts
+++ b/libs/auth/angular/ui/src/internal/auth-form-bridges.ts
@@ -9,17 +9,22 @@ import {
   UpdateEmailRequestDTO,
   VerifyEmailRequestDTO,
 } from '@anarchitects/auth-ts/dtos';
+import { type ResolvedAuthContracts } from '@anarchitects/auth-angular/config';
 import { SubmissionRequestDTO } from '@anarchitects/forms-ts/dtos';
-import { FormConfig } from '@anarchitects/forms-ts/models';
+import { FormConfig, type FormField } from '@anarchitects/forms-ts/models';
 
 type TokenContext = Readonly<{
   token?: string;
 }>;
 
 interface AuthFormBridge<TDto, TContext = undefined> {
-  resolveFormConfig(context?: TContext): FormConfig;
+  resolveFormConfig(
+    contracts?: ResolvedAuthContracts,
+    context?: TContext,
+  ): FormConfig;
   mapSubmission(
     input: SubmissionRequestDTO,
+    contracts?: ResolvedAuthContracts,
     context?: TContext,
   ): TDto | undefined;
 }
@@ -35,97 +40,6 @@ const matchFieldsRule = (sourceField: string, targetField: string) => ({
   targetField,
   message: 'Passwords must match.',
 });
-
-const LOGIN_FORM_CONFIG: FormConfig = {
-  id: 'login',
-  version: 1,
-  fields: [
-    {
-      name: 'credential',
-      kind: 'string',
-      required: true,
-      minLength: 2,
-      maxLength: 100,
-      ui: { label: 'Email or Username' },
-    },
-    {
-      name: 'password',
-      kind: 'password',
-      required: true,
-      minLength: 6,
-      ui: { label: 'Password' },
-    },
-  ],
-};
-
-const REGISTER_FORM_CONFIG: FormConfig = {
-  id: 'register',
-  version: 1,
-  fields: [
-    {
-      name: 'name',
-      kind: 'string',
-      ui: { label: 'Name' },
-      required: false,
-    },
-    { name: 'email', kind: 'email', ui: { label: 'Email' }, required: true },
-    {
-      name: 'password',
-      kind: 'password',
-      ui: { label: 'Password' },
-      required: true,
-    },
-    {
-      name: 'confirmPassword',
-      kind: 'password',
-      ui: { label: 'Confirm Password' },
-      required: true,
-    },
-  ],
-  validationRules: [matchFieldsRule('password', 'confirmPassword')],
-};
-
-const CHANGE_PASSWORD_FORM_CONFIG: FormConfig = {
-  id: 'change-password',
-  version: 1,
-  fields: [
-    {
-      name: 'currentPassword',
-      kind: 'password',
-      required: true,
-      minLength: 6,
-      ui: { label: 'Current Password' },
-    },
-    {
-      name: 'newPassword',
-      kind: 'password',
-      required: true,
-      minLength: 6,
-      ui: { label: 'New Password' },
-    },
-    {
-      name: 'confirmPassword',
-      kind: 'password',
-      required: true,
-      minLength: 6,
-      ui: { label: 'Confirm Password' },
-    },
-  ],
-  validationRules: [matchFieldsRule('newPassword', 'confirmPassword')],
-};
-
-const FORGOT_PASSWORD_FORM_CONFIG: FormConfig = {
-  id: 'forgot-password',
-  version: 1,
-  fields: [
-    {
-      name: 'email',
-      kind: 'email',
-      required: true,
-      ui: { label: 'Email' },
-    },
-  ],
-};
 
 const UPDATE_EMAIL_FORM_CONFIG: FormConfig = {
   id: 'update-email',
@@ -158,8 +72,57 @@ const resolveToken = (
   fallbackToken?: string,
 ): string | undefined => readPayloadString(input, 'token') || fallbackToken;
 
+type AuthFieldMeta = ResolvedAuthContracts['registerFormMeta']['email'];
+
+const requireContracts = (
+  contracts?: ResolvedAuthContracts,
+): ResolvedAuthContracts => {
+  if (!contracts) {
+    throw new Error('Auth contracts are required to resolve auth form config.');
+  }
+
+  return contracts;
+};
+
+const toFormField = (
+  name: string,
+  kind: FormField['kind'],
+  label: string,
+  meta: AuthFieldMeta,
+  overrides: Partial<FormField> = {},
+): FormField => ({
+  name,
+  kind,
+  required: meta.required,
+  minLength: meta.minLength,
+  maxLength: meta.maxLength,
+  ui: { label },
+  ...overrides,
+});
+
 export const loginFormBridge: AuthFormBridge<LoginRequestDTO> = {
-  resolveFormConfig: () => LOGIN_FORM_CONFIG,
+  resolveFormConfig: (contracts) => {
+    const resolvedContracts = requireContracts(contracts);
+
+    return {
+      id: 'login',
+      version: 1,
+      fields: [
+        toFormField(
+          'credential',
+          'string',
+          'Email or Username',
+          resolvedContracts.loginFormMeta.credential,
+        ),
+        toFormField(
+          'password',
+          'password',
+          'Password',
+          resolvedContracts.loginFormMeta.password,
+        ),
+      ],
+    };
+  },
   mapSubmission: (input) => ({
     credential: readPayloadString(input, 'credential') as string,
     password: readPayloadString(input, 'password') as string,
@@ -167,7 +130,41 @@ export const loginFormBridge: AuthFormBridge<LoginRequestDTO> = {
 };
 
 export const registerFormBridge: AuthFormBridge<RegisterRequestDTO> = {
-  resolveFormConfig: () => REGISTER_FORM_CONFIG,
+  resolveFormConfig: (contracts) => {
+    const resolvedContracts = requireContracts(contracts);
+
+    return {
+      id: 'register',
+      version: 1,
+      fields: [
+        toFormField(
+          'name',
+          'string',
+          'Name',
+          resolvedContracts.registerFormMeta.name,
+        ),
+        toFormField(
+          'email',
+          'email',
+          'Email',
+          resolvedContracts.registerFormMeta.email,
+        ),
+        toFormField(
+          'password',
+          'password',
+          'Password',
+          resolvedContracts.registerFormMeta.password,
+        ),
+        toFormField(
+          'confirmPassword',
+          'password',
+          'Confirm Password',
+          resolvedContracts.registerFormMeta.confirmPassword,
+        ),
+      ],
+      validationRules: [matchFieldsRule('password', 'confirmPassword')],
+    };
+  },
   mapSubmission: (input) => ({
     name: readPayloadString(input, 'name'),
     email: readPayloadString(input, 'email') as string,
@@ -180,7 +177,7 @@ export const activateUserFormBridge: AuthFormBridge<
   ActivateUserRequestDTO,
   TokenContext
 > = {
-  resolveFormConfig: (context) => ({
+  resolveFormConfig: (_contracts, context) => ({
     id: 'activate-user',
     version: 1,
     fields: [
@@ -193,7 +190,7 @@ export const activateUserFormBridge: AuthFormBridge<
       },
     ],
   }),
-  mapSubmission: (input, context) => {
+  mapSubmission: (input, _contracts, context) => {
     const token = resolveToken(input, context?.token);
     if (!token) {
       return undefined;
@@ -205,7 +202,22 @@ export const activateUserFormBridge: AuthFormBridge<
 
 export const forgotPasswordFormBridge: AuthFormBridge<ForgotPasswordRequestDTO> =
   {
-    resolveFormConfig: () => FORGOT_PASSWORD_FORM_CONFIG,
+    resolveFormConfig: (contracts) => {
+      const resolvedContracts = requireContracts(contracts);
+
+      return {
+        id: 'forgot-password',
+        version: 1,
+        fields: [
+          toFormField(
+            'email',
+            'email',
+            'Email',
+            resolvedContracts.forgotPasswordFormMeta.email,
+          ),
+        ],
+      };
+    },
     mapSubmission: (input) => ({
       email: readPayloadString(input, 'email') as string,
     }),
@@ -215,35 +227,41 @@ export const resetPasswordFormBridge: AuthFormBridge<
   ResetPasswordRequestDTO,
   TokenContext
 > = {
-  resolveFormConfig: (context) => ({
-    id: 'reset-password',
-    version: 1,
-    fields: [
-      {
-        name: 'token',
-        kind: 'string',
-        required: !context?.token,
-        minLength: 1,
-        ui: { label: 'Reset Token' },
-      },
-      {
-        name: 'password',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Password' },
-      },
-      {
-        name: 'confirmPassword',
-        kind: 'password',
-        required: true,
-        minLength: 6,
-        ui: { label: 'Confirm Password' },
-      },
-    ],
-    validationRules: [matchFieldsRule('password', 'confirmPassword')],
-  }),
-  mapSubmission: (input, context) => {
+  resolveFormConfig: (contracts, context) => {
+    const resolvedContracts = requireContracts(contracts);
+
+    return {
+      id: 'reset-password',
+      version: 1,
+      fields: [
+        toFormField(
+          'token',
+          'string',
+          'Reset Token',
+          resolvedContracts.resetPasswordFormMeta.token,
+          {
+            required: context?.token
+              ? false
+              : resolvedContracts.resetPasswordFormMeta.token.required,
+          },
+        ),
+        toFormField(
+          'password',
+          'password',
+          'Password',
+          resolvedContracts.resetPasswordFormMeta.password,
+        ),
+        toFormField(
+          'confirmPassword',
+          'password',
+          'Confirm Password',
+          resolvedContracts.resetPasswordFormMeta.confirmPassword,
+        ),
+      ],
+      validationRules: [matchFieldsRule('password', 'confirmPassword')],
+    };
+  },
+  mapSubmission: (input, _contracts, context) => {
     const token = resolveToken(input, context?.token);
     if (!token) {
       return undefined;
@@ -261,20 +279,28 @@ export const verifyEmailFormBridge: AuthFormBridge<
   VerifyEmailRequestDTO,
   TokenContext
 > = {
-  resolveFormConfig: (context) => ({
-    id: 'verify-email',
-    version: 1,
-    fields: [
-      {
-        name: 'token',
-        kind: 'string',
-        required: !context?.token,
-        minLength: 1,
-        ui: { label: 'Verification Token' },
-      },
-    ],
-  }),
-  mapSubmission: (input, context) => {
+  resolveFormConfig: (contracts, context) => {
+    const resolvedContracts = requireContracts(contracts);
+
+    return {
+      id: 'verify-email',
+      version: 1,
+      fields: [
+        toFormField(
+          'token',
+          'string',
+          'Verification Token',
+          resolvedContracts.verifyEmailFormMeta.token,
+          {
+            required: context?.token
+              ? false
+              : resolvedContracts.verifyEmailFormMeta.token.required,
+          },
+        ),
+      ],
+    };
+  },
+  mapSubmission: (input, _contracts, context) => {
     const token = resolveToken(input, context?.token);
     if (!token) {
       return undefined;
@@ -286,7 +312,35 @@ export const verifyEmailFormBridge: AuthFormBridge<
 
 export const changePasswordFormBridge: AuthFormBridge<ChangePasswordRequestDTO> =
   {
-    resolveFormConfig: () => CHANGE_PASSWORD_FORM_CONFIG,
+    resolveFormConfig: (contracts) => {
+      const resolvedContracts = requireContracts(contracts);
+
+      return {
+        id: 'change-password',
+        version: 1,
+        fields: [
+          toFormField(
+            'currentPassword',
+            'password',
+            'Current Password',
+            resolvedContracts.changePasswordFormMeta.currentPassword,
+          ),
+          toFormField(
+            'newPassword',
+            'password',
+            'New Password',
+            resolvedContracts.changePasswordFormMeta.newPassword,
+          ),
+          toFormField(
+            'confirmPassword',
+            'password',
+            'Confirm Password',
+            resolvedContracts.changePasswordFormMeta.confirmPassword,
+          ),
+        ],
+        validationRules: [matchFieldsRule('newPassword', 'confirmPassword')],
+      };
+    },
     mapSubmission: (input) => ({
       currentPassword: readPayloadString(input, 'currentPassword') as string,
       newPassword: readPayloadString(input, 'newPassword') as string,


### PR DESCRIPTION
Add auth contract DI to auth-angular config and wire the register, login, forgot-password, reset-password, verify-email, and change-password form bridges to build FormConfig from contract metadata instead of hard-coded field rules. Keep the shared contracts seam available to submission mapping for follow-up payload shaping work, and add config/component tests for nested overrides.

Closes #257 Refs #248