### PR TITLE
feat(auth-ts): shape auth payloads by empty-string policy

### DIFF
--- a/libs/auth/angular/state/src/auth.store.spec.ts
+++ b/libs/auth/angular/state/src/auth.store.spec.ts
@@ -3,7 +3,9 @@ import { Router } from '@angular/router';
 import { delay, of, throwError } from 'rxjs';
 import {
   AuthConfig,
+  AuthContractConfigOverrides,
   provideAuthConfig,
+  provideAuthContracts,
 } from '@anarchitects/auth-angular/config';
 import { AuthApi } from '@anarchitects/auth-angular/data-access';
 import { PolicyRule, User } from '@anarchitects/auth-ts/models';
@@ -51,10 +53,12 @@ const setup = ({
   authApiOverrides,
   stateOptions,
   authConfig,
+  contractOverrides,
 }: {
   authApiOverrides?: Partial<AuthApi>;
   stateOptions?: Parameters<typeof provideAuthState>[0];
   authConfig?: Partial<AuthConfig>;
+  contractOverrides?: AuthContractConfigOverrides;
 } = {}) => {
   const mockAuthApi = createMockAuthApi(authApiOverrides);
   const mockRouter = {
@@ -66,6 +70,7 @@ const setup = ({
       { provide: AuthApi, useValue: mockAuthApi },
       { provide: Router, useValue: mockRouter },
       ...provideAuthConfig(authConfig ?? {}),
+      ...provideAuthContracts(contractOverrides),
       ...provideAuthState(stateOptions),
     ],
   });
@@ -218,5 +223,172 @@ describe('AuthStore', () => {
 
     expect(localStorage.getItem('accessToken')).toBeNull();
     expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+
+  it('strips optional register name before calling AuthApi.registerUser', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        register: {
+          name: {
+            emptyStringPolicy: 'strip',
+          },
+        },
+      },
+    });
+
+    store.registerUser({
+      name: '',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.registerUser).toHaveBeenCalledWith({
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+  });
+
+  it('rejects empty optional login password before calling AuthApi.login', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        login: {
+          password: {
+            required: false,
+            emptyStringPolicy: 'reject',
+          },
+        },
+      },
+    });
+
+    store.login({
+      credential: 'user@example.com',
+      password: '',
+    });
+    await flushAsync();
+
+    expect(mockAuthApi.login).not.toHaveBeenCalled();
+    expect(store.error()).toContain('password');
+    expect(store.loading()).toBe(false);
+    expect(store.initialized()).toBe(true);
+  });
+
+  it('allows empty optional forgot-password email through to AuthApi.forgotPassword', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        forgotPassword: {
+          email: {
+            required: false,
+            emptyStringPolicy: 'allow',
+          },
+        },
+      },
+    });
+
+    store.forgotPassword({
+      email: '',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.forgotPassword).toHaveBeenCalledWith({
+      email: '',
+    });
+  });
+
+  it('strips optional reset token before calling AuthApi.resetPassword', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        resetPassword: {
+          token: {
+            required: false,
+            emptyStringPolicy: 'strip',
+          },
+        },
+      },
+    });
+
+    store.resetPassword({
+      dto: {
+        token: '',
+        password: 'secret123',
+        confirmPassword: 'secret123',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.resetPassword).toHaveBeenCalledWith({
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+  });
+
+  it('rejects empty optional verify-email token before calling AuthApi.verifyEmail', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        verifyEmail: {
+          token: {
+            required: false,
+            emptyStringPolicy: 'reject',
+          },
+        },
+      },
+    });
+
+    store.verifyEmail({
+      token: '',
+    });
+    await flushAsync();
+
+    expect(mockAuthApi.verifyEmail).not.toHaveBeenCalled();
+    expect(store.error()).toContain('token');
+    expect(store.loading()).toBe(false);
+  });
+
+  it('strips optional confirmPassword before calling AuthApi.changePassword', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+      contractOverrides: {
+        changePassword: {
+          confirmPassword: {
+            required: false,
+            emptyStringPolicy: 'strip',
+          },
+        },
+      },
+    });
+
+    store.changePassword({
+      userId: 'user-id',
+      dto: {
+        currentPassword: 'old-password',
+        newPassword: 'new-password',
+        confirmPassword: '',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.changePassword).toHaveBeenCalledWith('user-id', {
+      currentPassword: 'old-password',
+      newPassword: 'new-password',
+    });
   });
 });

--- a/libs/auth/angular/state/src/auth.store.ts
+++ b/libs/auth/angular/state/src/auth.store.ts
@@ -1,5 +1,10 @@
+import { injectAuthContracts } from '@anarchitects/auth-angular/config';
 import { AuthApi } from '@anarchitects/auth-angular/data-access';
 import { createAppAbility } from '@anarchitects/auth-angular/util';
+import {
+  type AuthPayloadFieldBehaviorMap,
+  shapeAuthPayload,
+} from '@anarchitects/auth-ts';
 import {
   ActivateUserRequestDTO,
   ChangePasswordRequestDTO,
@@ -30,7 +35,7 @@ import {
   withEntities,
 } from '@ngrx/signals/entities';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { EMPTY, pipe, switchMap, tap } from 'rxjs';
+import { EMPTY, defer, pipe, switchMap, tap } from 'rxjs';
 import { AUTH_STATE_OPTIONS } from './auth-state.options';
 
 type AuthState = {
@@ -82,32 +87,24 @@ const patchAuthenticatedSession = (
   store: object,
   session: { user: AuthUser; rbac: PolicyRule[] },
 ) => {
-  patchState(
-    store as never,
-    setAllEntities([session.user]),
-    {
-      ability: createAppAbility(session.rbac),
-      error: null,
-      rbac: session.rbac,
-      success: true,
-    },
-  );
+  patchState(store as never, setAllEntities([session.user]), {
+    ability: createAppAbility(session.rbac),
+    error: null,
+    rbac: session.rbac,
+    success: true,
+  });
 };
 
 const clearAuthenticatedSession = (
   store: object,
   state: Partial<AuthState> = {},
 ) => {
-  patchState(
-    store as never,
-    removeAllEntities(),
-    {
-      ability: undefined,
-      rbac: [],
-      success: false,
-      ...state,
-    },
-  );
+  patchState(store as never, removeAllEntities(), {
+    ability: undefined,
+    rbac: [],
+    success: false,
+    ...state,
+  });
 };
 
 const redirectToLogin = (router: Router | null): void => {
@@ -121,11 +118,17 @@ const redirectToLogin = (router: Router | null): void => {
   }
 };
 
+const shapePayloadForSubmit = <TPayload extends Record<string, unknown>>(
+  payload: TPayload,
+  fieldMap: AuthPayloadFieldBehaviorMap,
+): TPayload => shapeAuthPayload(payload, fieldMap);
+
 export const AuthStore = signalStore(
   withState(initialState),
   withEntities<AuthUser>(),
   withProps(() => ({
     _authApi: inject(AuthApi),
+    _authContracts: injectAuthContracts(),
     _authStateOptions: inject(AUTH_STATE_OPTIONS),
     _router: inject(Router, { optional: true }),
   })),
@@ -196,7 +199,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap((dto) =>
-          store._authApi.registerUser(dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.registerFormMeta,
+            ) as RegisterRequestDTO;
+
+            return store._authApi.registerUser(shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ success }) => {
                 patchState(store, { success });
@@ -236,7 +246,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap((dto) =>
-          store._authApi.login(dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.loginFormMeta,
+            ) as LoginRequestDTO;
+
+            return store._authApi.login(shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ user, rbac }) => {
                 const authenticatedUser = user as { email: string; id: string };
@@ -276,7 +293,9 @@ export const AuthStore = signalStore(
                 patchState(store, { success });
               },
               error: (error: unknown) => {
-                patchState(store, { error: toErrorMessage(error) });
+                patchState(store, {
+                  error: toErrorMessage(error),
+                });
               },
               finalize: () => {
                 patchState(store, { loading: false });
@@ -290,7 +309,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap(({ userId, dto }) =>
-          store._authApi.changePassword(userId, dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.changePasswordFormMeta,
+            ) as ChangePasswordRequestDTO;
+
+            return store._authApi.changePassword(userId, shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ success }) => {
                 patchState(store, { success });
@@ -310,7 +336,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap((dto) =>
-          store._authApi.forgotPassword(dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.forgotPasswordFormMeta,
+            ) as ForgotPasswordRequestDTO;
+
+            return store._authApi.forgotPassword(shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ success }) => {
                 patchState(store, { success });
@@ -330,7 +363,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap(({ dto }) =>
-          store._authApi.resetPassword(dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.resetPasswordFormMeta,
+            ) as ResetPasswordRequestDTO;
+
+            return store._authApi.resetPassword(shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ success }) => {
                 patchState(store, { success });
@@ -350,7 +390,14 @@ export const AuthStore = signalStore(
       pipe(
         tap(() => patchState(store, { loading: true, error: null })),
         switchMap((dto) =>
-          store._authApi.verifyEmail(dto).pipe(
+          defer(() => {
+            const shapedDto = shapePayloadForSubmit(
+              dto,
+              store._authContracts.verifyEmailFormMeta,
+            ) as VerifyEmailRequestDTO;
+
+            return store._authApi.verifyEmail(shapedDto);
+          }).pipe(
             tapResponse({
               next: ({ success }) => {
                 patchState(store, { success });

--- a/libs/auth/ts/src/contracts/index.ts
+++ b/libs/auth/ts/src/contracts/index.ts
@@ -2,3 +2,4 @@ export * from './auth-contract-compatibility';
 export * from './auth-contract.config';
 export * from './auth-contracts.factory';
 export * from './default-auth-contracts';
+export * from './shape-auth-payload';

--- a/libs/auth/ts/src/contracts/shape-auth-payload.spec.ts
+++ b/libs/auth/ts/src/contracts/shape-auth-payload.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { createAuthContracts } from './auth-contracts.factory';
+import { DefaultAuthContractConfig } from './auth-contract.config';
+import { shapeAuthPayload } from './shape-auth-payload';
+
+describe('shapeAuthPayload', () => {
+  it('strips empty optional fields when policy is strip', () => {
+    const contracts = createAuthContracts({
+      ...DefaultAuthContractConfig,
+      register: {
+        ...DefaultAuthContractConfig.register,
+        name: {
+          ...DefaultAuthContractConfig.register.name,
+          emptyStringPolicy: 'strip',
+        },
+      },
+    });
+
+    expect(
+      shapeAuthPayload(
+        {
+          name: '',
+          email: 'jane@example.com',
+          password: 'secret123',
+          confirmPassword: 'secret123',
+        },
+        contracts.registerFormMeta,
+      ),
+    ).toEqual({
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+  });
+
+  it('throws for empty optional fields when policy is reject', () => {
+    const contracts = createAuthContracts(DefaultAuthContractConfig);
+
+    expect(() =>
+      shapeAuthPayload(
+        {
+          name: '',
+          email: 'jane@example.com',
+          password: 'secret123',
+          confirmPassword: 'secret123',
+        },
+        contracts.registerFormMeta,
+      ),
+    ).toThrow(/name/);
+  });
+
+  it('keeps empty optional fields when policy is allow', () => {
+    const contracts = createAuthContracts({
+      ...DefaultAuthContractConfig,
+      forgotPassword: {
+        email: {
+          ...DefaultAuthContractConfig.forgotPassword.email,
+          required: false,
+          emptyStringPolicy: 'allow',
+        },
+      },
+    });
+
+    expect(
+      shapeAuthPayload(
+        {
+          email: '',
+        },
+        contracts.forgotPasswordFormMeta,
+      ),
+    ).toEqual({
+      email: '',
+    });
+  });
+
+  it('leaves required fields unchanged even when they are empty strings', () => {
+    const contracts = createAuthContracts(DefaultAuthContractConfig);
+
+    expect(
+      shapeAuthPayload(
+        {
+          credential: '',
+          password: 'secret123',
+        },
+        contracts.loginFormMeta,
+      ),
+    ).toEqual({
+      credential: '',
+      password: 'secret123',
+    });
+  });
+
+  it('does not mutate the input payload', () => {
+    const contracts = createAuthContracts({
+      ...DefaultAuthContractConfig,
+      register: {
+        ...DefaultAuthContractConfig.register,
+        name: {
+          ...DefaultAuthContractConfig.register.name,
+          emptyStringPolicy: 'strip',
+        },
+      },
+    });
+    const payload = {
+      name: '',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    };
+
+    const shaped = shapeAuthPayload(payload, contracts.registerFormMeta);
+
+    expect(shaped).not.toBe(payload);
+    expect(payload).toEqual({
+      name: '',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+  });
+
+  it('passes through unknown keys unchanged', () => {
+    const contracts = createAuthContracts(DefaultAuthContractConfig);
+
+    expect(
+      shapeAuthPayload(
+        {
+          email: 'jane@example.com',
+          extra: '',
+        },
+        contracts.forgotPasswordFormMeta,
+      ),
+    ).toEqual({
+      email: 'jane@example.com',
+      extra: '',
+    });
+  });
+});

--- a/libs/auth/ts/src/contracts/shape-auth-payload.ts
+++ b/libs/auth/ts/src/contracts/shape-auth-payload.ts
@@ -1,0 +1,37 @@
+import type { AuthFieldMeta } from './auth-contracts.factory';
+
+export type AuthPayloadFieldBehavior = Pick<
+  AuthFieldMeta,
+  'required' | 'emptyStringPolicy'
+>;
+
+export type AuthPayloadFieldBehaviorMap = Record<
+  string,
+  AuthPayloadFieldBehavior
+>;
+
+export function shapeAuthPayload<
+  TPayload extends Record<string, unknown>,
+  TFieldMap extends AuthPayloadFieldBehaviorMap,
+>(payload: TPayload, fieldMap: TFieldMap): TPayload {
+  const shapedEntries = Object.entries(payload).flatMap(([key, value]) => {
+    const fieldBehavior = fieldMap[key];
+
+    if (!fieldBehavior || fieldBehavior.required || value !== '') {
+      return [[key, value] as const];
+    }
+
+    switch (fieldBehavior.emptyStringPolicy) {
+      case 'allow':
+        return [[key, value] as const];
+      case 'strip':
+        return [];
+      case 'reject':
+        throw new Error(
+          `Empty string is not allowed for optional field "${key}".`,
+        );
+    }
+  });
+
+  return Object.fromEntries(shapedEntries) as TPayload;
+}


### PR DESCRIPTION
Add a pure `shapeAuthPayload(...)` helper to `@anarchitects/auth-ts` and wire `AuthStore` to apply contract-driven payload shaping before calling `AuthApi` for the contract-backed auth flows. This strips, rejects, or preserves empty optional fields according to `emptyStringPolicy`, and adds helper/store tests for the supported behaviors.

Closes #258 Refs #248