### PR TITLE
test(auth-angular): strengthen contract-driven form behavior coverage

### DIFF
--- a/.agents/skills/project-board-sync/SKILL.md
+++ b/.agents/skills/project-board-sync/SKILL.md
@@ -30,11 +30,12 @@ Use this skill during issue-driven implementation to keep the planning board ali
 
 3. Review handoff:
 
-- Set issue to In Review when implementation is complete and review is requested or a PR is opened.
+- Set issue to In Review when implementation is complete and awaiting human review, approval, or PR handling.
+- If a PR is opened, keep the issue in In Review unless a human explicitly accepts or closes the work.
 
 4. Completion:
 
-- Set Done only after completion criteria are met.
+- Set Done only after a human accepts the implementation, explicitly signs off, or merges the corresponding PR.
 
 ## Common Board Operations
 
@@ -59,9 +60,9 @@ Use this skill during issue-driven implementation to keep the planning board ali
 - Backlog: prioritized but not selected for active execution.
 - Todo: selected for active sprint but not started.
 - In Progress: currently being implemented.
-- In Review: implementation ready for review or PR stage.
+- In Review: implementation is finished by the agent and is awaiting human review, approval, or PR completion.
 - Blocked: waiting for dependency, decision, or environment fix.
-- Done: accepted and complete.
+- Done: human-accepted and complete.
 
 ## Safety Rules
 
@@ -75,5 +76,6 @@ Use this skill during issue-driven implementation to keep the planning board ali
 - Treat board updates as AI-assisted planning operations under human supervision.
 - Human developers review code, perform commits, create PRs, and merge PRs.
 - AI coding agents may suggest commit messages, but commit execution remains human-owned.
+- AI coding agents must not move an issue directly from active development to Done without explicit human acceptance.
 - When implementation changes may be breaking, explicitly call that out in updates and summaries.
 - When bug-fix impact suggests package deprecation on npm, explicitly call this out and require explicit human approval before any deprecation execution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,8 +122,9 @@ When executing work tied to GitHub issues in this repository, keep the planning 
 - If work is intentionally queued or deferred, set Status to Backlog.
 - If work is ready and selected for active execution but not started, set Status to Todo.
 - If blocked by dependency, environment, or decision gate, set Status to Blocked.
-- When a PR is opened for the issue, set Status to In Review.
-- When work is fully completed and validated, set Status to Done.
+- When implementation is complete and awaiting human review, approval, or PR handling, set Status to In Review.
+- When a PR is opened for the issue, keep or move Status to In Review.
+- Set Status to Done only after human acceptance, explicit signoff, or merge confirms the work is complete.
 
 ### Scope Rules
 
@@ -142,6 +143,7 @@ For all implementation work, keep humans as the control point for code acceptanc
 - Human developers review all code changes.
 - Human developers perform git commit, pull request creation, and pull request merge.
 - AI coding agents must never finalize commits or merge PRs as a replacement for human review.
+- AI coding agents must not mark issue work as Done based only on local implementation and validation; the correct handoff state is In Review until a human accepts the work.
 
 ### Breaking Change And Deprecation Disclosure
 

--- a/libs/auth/angular/state/src/auth.store.spec.ts
+++ b/libs/auth/angular/state/src/auth.store.spec.ts
@@ -225,6 +225,161 @@ describe('AuthStore', () => {
     expect(localStorage.getItem('refreshToken')).toBeNull();
   });
 
+  it('passes the default register payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.registerUser({
+      name: 'Jane',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.registerUser).toHaveBeenCalledWith({
+      name: 'Jane',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.success()).toBe(true);
+  });
+
+  it('rejects the default optional register name when submitted as an empty string', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.registerUser({
+      name: '',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+    await flushAsync();
+
+    expect(mockAuthApi.registerUser).not.toHaveBeenCalled();
+    expect(store.error()).toContain('name');
+    expect(store.loading()).toBe(false);
+  });
+
+  it('passes the default login payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.login({
+      credential: 'user@example.com',
+      password: 'secret123',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.login).toHaveBeenCalledWith({
+      credential: 'user@example.com',
+      password: 'secret123',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.isLoggedIn()).toBe(true);
+  });
+
+  it('passes the default forgot-password payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.forgotPassword({
+      email: 'user@example.com',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.forgotPassword).toHaveBeenCalledWith({
+      email: 'user@example.com',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.success()).toBe(true);
+  });
+
+  it('passes the default reset-password payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.resetPassword({
+      dto: {
+        token: 'reset-token',
+        password: 'secret123',
+        confirmPassword: 'secret123',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.resetPassword).toHaveBeenCalledWith({
+      token: 'reset-token',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.success()).toBe(true);
+  });
+
+  it('passes the default verify-email payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.verifyEmail({
+      token: 'verify-token',
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.verifyEmail).toHaveBeenCalledWith({
+      token: 'verify-token',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.success()).toBe(true);
+  });
+
+  it('passes the default change-password payload through unchanged on success', async () => {
+    const { store, mockAuthApi } = setup({
+      stateOptions: {
+        restoreOnInit: false,
+      },
+    });
+
+    store.changePassword({
+      userId: 'user-id',
+      dto: {
+        currentPassword: 'old-password',
+        newPassword: 'new-password',
+        confirmPassword: 'new-password',
+      },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(mockAuthApi.changePassword).toHaveBeenCalledWith('user-id', {
+      currentPassword: 'old-password',
+      newPassword: 'new-password',
+      confirmPassword: 'new-password',
+    });
+    expect(store.error()).toBeNull();
+    expect(store.success()).toBe(true);
+  });
+
   it('strips optional register name before calling AuthApi.registerUser', async () => {
     const { store, mockAuthApi } = setup({
       stateOptions: {

--- a/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/change-password-form/change-password-form.spec.ts
@@ -25,6 +25,41 @@ describe('AnarchitectsAuthUiChangePasswordForm', () => {
     await setup();
   });
 
+  const getChangePasswordControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const currentPasswordInput = nativeElement.querySelector(
+      'input#currentPassword',
+    ) as HTMLInputElement | null;
+    const newPasswordInput = nativeElement.querySelector(
+      'input#newPassword',
+    ) as HTMLInputElement | null;
+    const confirmPasswordInput = nativeElement.querySelector(
+      'input#confirmPassword',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (
+      !currentPasswordInput ||
+      !newPasswordInput ||
+      !confirmPasswordInput ||
+      !submitButton
+    ) {
+      throw new Error('Expected change-password form controls to be rendered.');
+    }
+
+    return {
+      nativeElement,
+      currentPasswordInput,
+      newPasswordInput,
+      confirmPasswordInput,
+      submitButton,
+    };
+  };
+
   it('should configure confirmPassword to match newPassword', () => {
     expect(component.formConfig().validationRules).toEqual([
       {
@@ -60,6 +95,75 @@ describe('AnarchitectsAuthUiChangePasswordForm', () => {
         .formConfig()
         .fields.find((field) => field.name === 'newPassword')?.minLength,
     ).toBe(10);
+  });
+
+  it('should keep submit disabled when required change-password fields are missing by default', async () => {
+    const { currentPasswordInput, submitButton } = getChangePasswordControls();
+
+    currentPasswordInput.value = 'old-password';
+    currentPasswordInput.dispatchEvent(new Event('input'));
+    currentPasswordInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should allow submit when confirmPassword is optional and omitted', async () => {
+    await setup(
+      provideAuthContracts({
+        changePassword: {
+          confirmPassword: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { currentPasswordInput, newPasswordInput, submitButton } =
+      getChangePasswordControls();
+
+    currentPasswordInput.value = 'old-password';
+    currentPasswordInput.dispatchEvent(new Event('input'));
+    newPasswordInput.value = 'new-password';
+    newPasswordInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should show the contract-driven newPassword minLength validation message', async () => {
+    await setup(
+      provideAuthContracts({
+        changePassword: {
+          newPassword: {
+            minLength: 10,
+          },
+        },
+      }),
+    );
+
+    const {
+      nativeElement,
+      currentPasswordInput,
+      newPasswordInput,
+      confirmPasswordInput,
+      submitButton,
+    } = getChangePasswordControls();
+
+    currentPasswordInput.value = 'old-password';
+    currentPasswordInput.dispatchEvent(new Event('input'));
+    newPasswordInput.value = 'short';
+    newPasswordInput.dispatchEvent(new Event('input'));
+    newPasswordInput.dispatchEvent(new Event('blur'));
+    confirmPasswordInput.value = 'short';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Minimum length is 10.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should map submission payload to ChangePasswordRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/forgot-password-form/forgot-password-form.spec.ts
@@ -25,6 +25,24 @@ describe('AnarchitectsAuthUiForgotPasswordForm', () => {
     await setup();
   });
 
+  const getForgotPasswordControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const emailInput = nativeElement.querySelector(
+      'input#email',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (!emailInput || !submitButton) {
+      throw new Error('Expected forgot-password form controls to be rendered.');
+    }
+
+    return { nativeElement, emailInput, submitButton };
+  };
+
   it('should read contract-driven email required metadata', async () => {
     await setup(
       provideAuthContracts({
@@ -37,6 +55,59 @@ describe('AnarchitectsAuthUiForgotPasswordForm', () => {
     );
 
     expect(component.formConfig().fields[0]?.required).toBe(false);
+  });
+
+  it('should keep submit disabled when email is missing by default', async () => {
+    const { emailInput, submitButton } = getForgotPasswordControls();
+
+    emailInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should allow submit without email when the field is optional', async () => {
+    await setup(
+      provideAuthContracts({
+        forgotPassword: {
+          email: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { submitButton } = getForgotPasswordControls();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should still validate email format when a value is provided', async () => {
+    await setup(
+      provideAuthContracts({
+        forgotPassword: {
+          email: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { nativeElement, emailInput, submitButton } =
+      getForgotPasswordControls();
+
+    emailInput.value = 'not-an-email';
+    emailInput.dispatchEvent(new Event('input'));
+    emailInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Enter a valid email address.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should map submission payload to ForgotPasswordRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/login-form/login-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/login-form/login-form.spec.ts
@@ -25,6 +25,27 @@ describe('AnarchitectsAuthUiLoginForm', () => {
     await setup();
   });
 
+  const getLoginControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const credentialInput = nativeElement.querySelector(
+      'input#credential',
+    ) as HTMLInputElement | null;
+    const passwordInput = nativeElement.querySelector(
+      'input#password',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (!credentialInput || !passwordInput || !submitButton) {
+      throw new Error('Expected login form controls to be rendered.');
+    }
+
+    return { nativeElement, credentialInput, passwordInput, submitButton };
+  };
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -49,6 +70,66 @@ describe('AnarchitectsAuthUiLoginForm', () => {
       component.formConfig().fields.find((field) => field.name === 'password')
         ?.minLength,
     ).toBe(10);
+  });
+
+  it('should keep submit disabled when required login fields are missing by default', async () => {
+    const { credentialInput, submitButton } = getLoginControls();
+
+    credentialInput.value = 'user@example.com';
+    credentialInput.dispatchEvent(new Event('input'));
+    credentialInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should allow submit when password is optional under a custom profile', async () => {
+    await setup(
+      provideAuthContracts({
+        login: {
+          password: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { credentialInput, submitButton } = getLoginControls();
+
+    credentialInput.value = 'user@example.com';
+    credentialInput.dispatchEvent(new Event('input'));
+    credentialInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should show the contract-driven password minLength validation message', async () => {
+    await setup(
+      provideAuthContracts({
+        login: {
+          password: {
+            minLength: 10,
+          },
+        },
+      }),
+    );
+
+    const { nativeElement, credentialInput, passwordInput, submitButton } =
+      getLoginControls();
+
+    credentialInput.value = 'user@example.com';
+    credentialInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'short';
+    passwordInput.dispatchEvent(new Event('input'));
+    passwordInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Minimum length is 10.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should map submission payload to LoginRequestDTO', () => {

--- a/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/register-form/register-form.spec.ts
@@ -25,6 +25,46 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
     await setup();
   });
 
+  const getRegisterControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const nameInput = nativeElement.querySelector(
+      'input#name',
+    ) as HTMLInputElement | null;
+    const emailInput = nativeElement.querySelector(
+      'input#email',
+    ) as HTMLInputElement | null;
+    const passwordInput = nativeElement.querySelector(
+      'input#password',
+    ) as HTMLInputElement | null;
+    const confirmPasswordInput = nativeElement.querySelector(
+      'input#confirmPassword',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (
+      !nameInput ||
+      !emailInput ||
+      !passwordInput ||
+      !confirmPasswordInput ||
+      !submitButton
+    ) {
+      throw new Error('Expected register form controls to be rendered.');
+    }
+
+    return {
+      nativeElement,
+      nameInput,
+      emailInput,
+      passwordInput,
+      confirmPasswordInput,
+      submitButton,
+    };
+  };
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -55,6 +95,92 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
       component.formConfig().fields.find((field) => field.name === 'name')
         ?.required,
     ).toBe(true);
+  });
+
+  it('should allow submit without name by default', async () => {
+    const { emailInput, passwordInput, confirmPasswordInput, submitButton } =
+      getRegisterControls();
+
+    emailInput.value = 'jane@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret123';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should require name when the custom profile marks it required', async () => {
+    await setup(
+      provideAuthContracts({
+        register: {
+          name: {
+            required: true,
+          },
+        },
+      }),
+    );
+
+    const {
+      nativeElement,
+      emailInput,
+      passwordInput,
+      confirmPasswordInput,
+      nameInput,
+      submitButton,
+    } = getRegisterControls();
+
+    emailInput.value = 'jane@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret123';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    nameInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('This field is required.');
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should show the contract-driven name minLength validation message', async () => {
+    await setup(
+      provideAuthContracts({
+        register: {
+          name: {
+            minLength: 5,
+          },
+        },
+      }),
+    );
+
+    const {
+      nativeElement,
+      emailInput,
+      passwordInput,
+      confirmPasswordInput,
+      nameInput,
+      submitButton,
+    } = getRegisterControls();
+
+    emailInput.value = 'jane@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret123';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    nameInput.value = 'Joe';
+    nameInput.dispatchEvent(new Event('input'));
+    nameInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Minimum length is 5.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should map submission payload to RegisterRequestDTO', () => {
@@ -90,35 +216,13 @@ describe('AnarchitectsAuthUiRegisterForm', () => {
       emitted = value;
     });
 
-    fixture.detectChanges();
-
-    const nativeElement = fixture.nativeElement as HTMLElement;
-    const emailInput = nativeElement.querySelector(
-      'input#email',
-    ) as HTMLInputElement | null;
-    const passwordInput = nativeElement.querySelector(
-      'input#password',
-    ) as HTMLInputElement | null;
-    const confirmPasswordInput = nativeElement.querySelector(
-      'input#confirmPassword',
-    ) as HTMLInputElement | null;
-    const submitButton = nativeElement.querySelector(
-      'button[type="submit"]',
-    ) as HTMLButtonElement | null;
-
-    expect(emailInput).toBeTruthy();
-    expect(passwordInput).toBeTruthy();
-    expect(confirmPasswordInput).toBeTruthy();
-    expect(submitButton).toBeTruthy();
-
-    if (
-      !emailInput ||
-      !passwordInput ||
-      !confirmPasswordInput ||
-      !submitButton
-    ) {
-      throw new Error('Expected register form inputs to be rendered.');
-    }
+    const {
+      nativeElement,
+      emailInput,
+      passwordInput,
+      confirmPasswordInput,
+      submitButton,
+    } = getRegisterControls();
 
     emailInput.value = 'jane@example.com';
     emailInput.dispatchEvent(new Event('input'));

--- a/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/reset-password-form/reset-password-form.spec.ts
@@ -27,6 +27,41 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
     await setup();
   });
 
+  const getResetPasswordControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const tokenInput = nativeElement.querySelector(
+      'input#token',
+    ) as HTMLInputElement | null;
+    const passwordInput = nativeElement.querySelector(
+      'input#password',
+    ) as HTMLInputElement | null;
+    const confirmPasswordInput = nativeElement.querySelector(
+      'input#confirmPassword',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (
+      !tokenInput ||
+      !passwordInput ||
+      !confirmPasswordInput ||
+      !submitButton
+    ) {
+      throw new Error('Expected reset-password form controls to be rendered.');
+    }
+
+    return {
+      nativeElement,
+      tokenInput,
+      passwordInput,
+      confirmPasswordInput,
+      submitButton,
+    };
+  };
+
   it('should configure confirmPassword to match password', () => {
     expect(component.formConfig().validationRules).toEqual([
       {
@@ -53,6 +88,76 @@ describe('AnarchitectsAuthUiResetPasswordForm', () => {
       component.formConfig().fields.find((field) => field.name === 'token')
         ?.minLength,
     ).toBe(8);
+  });
+
+  it('should keep submit disabled when required reset-password fields are missing by default', async () => {
+    const { passwordInput, submitButton } = getResetPasswordControls();
+
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    passwordInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should allow submit without token when the custom profile makes it optional', async () => {
+    await setup(
+      provideAuthContracts({
+        resetPassword: {
+          token: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { passwordInput, confirmPasswordInput, submitButton } =
+      getResetPasswordControls();
+
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret123';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should show the contract-driven token minLength validation message', async () => {
+    await setup(
+      provideAuthContracts({
+        resetPassword: {
+          token: {
+            required: false,
+            minLength: 8,
+          },
+        },
+      }),
+    );
+
+    const {
+      nativeElement,
+      tokenInput,
+      passwordInput,
+      confirmPasswordInput,
+      submitButton,
+    } = getResetPasswordControls();
+
+    passwordInput.value = 'secret123';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmPasswordInput.value = 'secret123';
+    confirmPasswordInput.dispatchEvent(new Event('input'));
+    tokenInput.value = 'short';
+    tokenInput.dispatchEvent(new Event('input'));
+    tokenInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Minimum length is 8.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should map payload token and password fields', () => {

--- a/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.spec.ts
+++ b/libs/auth/angular/ui/src/components/verify-email-form/verify-email-form.spec.ts
@@ -27,6 +27,24 @@ describe('AnarchitectsAuthUiVerifyEmailForm', () => {
     await setup();
   });
 
+  const getVerifyEmailControls = () => {
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const tokenInput = nativeElement.querySelector(
+      'input#token',
+    ) as HTMLInputElement | null;
+    const submitButton = nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement | null;
+
+    if (!tokenInput || !submitButton) {
+      throw new Error('Expected verify-email form controls to be rendered.');
+    }
+
+    return { nativeElement, tokenInput, submitButton };
+  };
+
   it('should read contract-driven token minLength', async () => {
     await setup(
       provideAuthContracts({
@@ -39,6 +57,60 @@ describe('AnarchitectsAuthUiVerifyEmailForm', () => {
     );
 
     expect(component.formConfig().fields[0]?.minLength).toBe(8);
+  });
+
+  it('should keep submit disabled when token is missing by default', async () => {
+    const { tokenInput, submitButton } = getVerifyEmailControls();
+
+    tokenInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should allow submit without token when the custom profile makes it optional', async () => {
+    await setup(
+      provideAuthContracts({
+        verifyEmail: {
+          token: {
+            required: false,
+          },
+        },
+      }),
+    );
+
+    const { submitButton } = getVerifyEmailControls();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(submitButton.disabled).toBe(false);
+  });
+
+  it('should show the contract-driven token minLength validation message', async () => {
+    await setup(
+      provideAuthContracts({
+        verifyEmail: {
+          token: {
+            required: false,
+            minLength: 8,
+          },
+        },
+      }),
+    );
+
+    const { nativeElement, tokenInput, submitButton } =
+      getVerifyEmailControls();
+
+    tokenInput.value = 'short';
+    tokenInput.dispatchEvent(new Event('input'));
+    tokenInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(nativeElement.textContent).toContain('Minimum length is 8.');
+    expect(submitButton.disabled).toBe(true);
   });
 
   it('should use token input fallback when payload token is missing', () => {

--- a/libs/forms/angular/ui/src/form.spec.ts
+++ b/libs/forms/angular/ui/src/form.spec.ts
@@ -331,6 +331,43 @@ describe('Form', () => {
     expect(component.fieldErrorMessage('confirmPassword')).toBeNull();
   });
 
+  it('should allow an optional matchFields target to remain empty', () => {
+    const config: FormConfig = {
+      id: 'change-password',
+      version: 1,
+      fields: [
+        { name: 'newPassword', kind: 'password', minLength: 6, required: true },
+        {
+          name: 'confirmPassword',
+          kind: 'password',
+          minLength: 6,
+          required: false,
+        },
+      ],
+      validationRules: [
+        {
+          kind: 'matchFields',
+          sourceField: 'newPassword',
+          targetField: 'confirmPassword',
+          message: 'Passwords must match.',
+        },
+      ],
+    };
+
+    ref.setInput('config', config);
+    fixture.detectChanges();
+
+    component.formGroup.setValue({
+      newPassword: 'secret123',
+      confirmPassword: '',
+    });
+    component.formGroup.get('confirmPassword')?.markAsTouched();
+    fixture.detectChanges();
+
+    expect(component.formGroup.valid).toBe(true);
+    expect(component.fieldErrorMessage('confirmPassword')).toBeNull();
+  });
+
   it('should compose runtime validators with declarative validation rules', () => {
     const config: FormConfig = {
       id: 'register',

--- a/libs/forms/angular/ui/src/form.ts
+++ b/libs/forms/angular/ui/src/form.ts
@@ -86,6 +86,17 @@ function buildConfigValidator(
         continue;
       }
 
+      if (targetControl.value === null || targetControl.value === undefined) {
+        continue;
+      }
+
+      if (
+        typeof targetControl.value === 'string' &&
+        targetControl.value === ''
+      ) {
+        continue;
+      }
+
       if (sourceControl.value === targetControl.value) {
         continue;
       }
@@ -230,8 +241,8 @@ export class AnarchitectsUiForm {
 
     return Boolean(
       control &&
-      this.crossFieldError(fieldName) &&
-      (control.touched || control.dirty),
+        this.crossFieldError(fieldName) &&
+        (control.touched || control.dirty),
     );
   }
 
@@ -286,7 +297,7 @@ export class AnarchitectsUiForm {
 
     return Boolean(
       (control && control.touched && control.invalid) ||
-      this.shouldShowCrossFieldError(fieldName),
+        this.shouldShowCrossFieldError(fieldName),
     );
   }
 


### PR DESCRIPTION
Expand auth-angular form specs to verify required/optional and minLength behavior through the rendered shared form component, and extend AuthStore coverage for default and override contract profiles across the six contract-driven auth flows.

Fix the shared matchFields validator so an empty optional target field does not fail cross-field validation, with guardrail coverage in forms-angular.

Closes #259 Refs #248