### PR TITLE
docs(auth-ts,auth-nest,auth-angular): add contract configuration and migration guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@
 
 - Define DTOs and models under `libs/*/ts`.
 - Angular and Nest libraries consume these shared types.
+- When contract-driven behavior changes, update the affected package READMEs and any relevant migration guide under `docs/guides/`.
 
 3. Library-first architecture
 
@@ -45,6 +46,7 @@ yarn install
 # API docs pipeline
 nx run api-specs:generate
 nx run api-specs:lint
+nx run api-specs:diff
 nx run api-specs:verify
 
 # If you add/change a route, update:

--- a/docs/guides/auth-contracts-migration.md
+++ b/docs/guides/auth-contracts-migration.md
@@ -1,0 +1,223 @@
+# Auth Contract Migration Guide
+
+## Intent
+
+This guide covers the move from hard-coded auth DTO request schemas to the contract-driven auth profile model shared by `@anarchitects/auth-ts`, `@anarchitects/auth-nest`, and `@anarchitects/auth-angular`.
+
+Use this guide when a consumer needs to customize auth field requirements, length limits, or empty-string handling without forking package code.
+
+## What Changed
+
+Before this shift, auth request behavior was effectively fixed by static DTO request schema exports such as:
+
+- `RegisterRequestSchema`
+- `LoginRequestSchema`
+- `ForgotPasswordRequestSchema`
+- `ResetPasswordRequestSchema`
+- `VerifyEmailRequestSchema`
+- `ChangePasswordRequestSchema`
+
+Those exports still exist, but they are now default-profile convenience helpers built from `DefaultAuthContractConfig`.
+
+The new integration seam is the contract profile model:
+
+- `AuthContractConfig`
+- `DefaultAuthContractConfig`
+- `createAuthContracts(...)`
+- `assertContractCompatibility(...)`
+- `shapeAuthPayload(...)`
+
+This is the important behavioral change:
+
+- use static DTO schema exports when the published default profile is enough
+- use `createAuthContracts(...)` when validation or form behavior must be customized
+
+## Export Surface Changes
+
+### Newly important exports
+
+Use these exports as the new source of truth for profile-driven auth behavior:
+
+| Package                             | Export                                        | Purpose                                                          |
+| ----------------------------------- | --------------------------------------------- | ---------------------------------------------------------------- |
+| `@anarchitects/auth-ts`             | `AuthContractConfig`                          | Type the contract profile                                        |
+| `@anarchitects/auth-ts`             | `DefaultAuthContractConfig`                   | Published default profile                                        |
+| `@anarchitects/auth-ts`             | `createAuthContracts(...)`                    | Generate request schemas and form metadata                       |
+| `@anarchitects/auth-ts`             | `assertContractCompatibility(...)`            | Fail fast on unexpected profile versions                         |
+| `@anarchitects/auth-ts`             | `shapeAuthPayload(...)`                       | Apply `emptyStringPolicy` before submit                          |
+| `@anarchitects/auth-nest`           | `AuthModule.forRoot({ contracts })`           | Override backend validation profile                              |
+| `@anarchitects/auth-nest`           | `AuthModule.forRootFromConfig({ contracts })` | Override backend validation while other options come from config |
+| `@anarchitects/auth-angular/config` | `provideAuthContracts(...)`                   | Override frontend form and submit-shaping profile                |
+
+### Removed or renamed exports
+
+No core auth DTO type aliases were removed or renamed as part of this migration.
+
+- `LoginRequestDTO`, `RegisterRequestDTO`, and the other request DTO types remain valid.
+- Static schema exports such as `LoginRequestSchema` also remain valid.
+- The migration is about which exports you should treat as the customization seam, not about deleting the DTO surface.
+
+## Old To New Mapping
+
+| Previous pattern                                                 | New pattern                                                                                                       |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Import a fixed request schema constant for runtime customization | Build a profile with `createAuthContracts(...)` and consume `*.RequestSchema` from the generated contracts object |
+| Keep frontend validators hard-coded in auth-angular              | Provide a shared profile with `provideAuthContracts(...)` so UI rules come from contract metadata                 |
+| Keep backend Fastify validation fixed to DTO schemas             | Pass `contracts` into `AuthModule.forRoot(...)` or `AuthModule.forRootFromConfig(...)`                            |
+| Manually strip empty optional fields in UI code                  | Let `AuthStore` apply `shapeAuthPayload(...)` based on `emptyStringPolicy`                                        |
+
+## `@anarchitects/auth-ts` Migration
+
+If you only consume DTO types, no change is required.
+
+If you customize auth request rules, switch to a generated contracts object:
+
+```ts
+import { type AuthContractConfig, DefaultAuthContractConfig, assertContractCompatibility, createAuthContracts } from '@anarchitects/auth-ts';
+
+const profile: AuthContractConfig = {
+  ...DefaultAuthContractConfig,
+  version: '1.0.0',
+  register: {
+    ...DefaultAuthContractConfig.register,
+    name: {
+      ...DefaultAuthContractConfig.register.name,
+      required: true,
+      minLength: 3,
+      emptyStringPolicy: 'strip',
+    },
+  },
+};
+
+assertContractCompatibility(profile, '1.0.0');
+
+const contracts = createAuthContracts(profile);
+```
+
+Then consume `contracts.registerRequestSchema`, `contracts.loginRequestSchema`, and the matching `*.FormMeta` values instead of relying on fixed schema constants as your customization seam.
+
+## `@anarchitects/auth-nest` Migration
+
+Backend validation is now contract-driven at module bootstrap.
+
+Default profile:
+
+```ts
+import { AuthModule } from '@anarchitects/auth-nest';
+
+AuthModule.forRoot({
+  presentation: {
+    application: {
+      encryption: {
+        algorithm: 'bcrypt',
+        key: process.env.AUTH_ENCRYPTION_KEY!,
+      },
+    },
+  },
+});
+```
+
+Custom profile:
+
+```ts
+import { AuthModule } from '@anarchitects/auth-nest';
+
+AuthModule.forRoot({
+  contracts: {
+    register: {
+      name: {
+        required: true,
+        minLength: 3,
+      },
+    },
+  },
+  presentation: {
+    application: {
+      encryption: {
+        algorithm: 'bcrypt',
+        key: process.env.AUTH_ENCRYPTION_KEY!,
+      },
+    },
+  },
+});
+```
+
+Config-driven composition uses the same `contracts` override path:
+
+```ts
+AuthModule.forRootFromConfig({
+  contracts: {
+    login: {
+      password: {
+        required: false,
+      },
+    },
+  },
+});
+```
+
+There is intentionally no dedicated `AUTH_*` contract env tree yet. Contract customization is explicit and code-level.
+
+## `@anarchitects/auth-angular` Migration
+
+Frontend auth forms and submit shaping now consume the same contract profile.
+
+Default profile:
+
+```ts
+import { provideAuthConfig } from '@anarchitects/auth-angular/config';
+import { provideAuthState } from '@anarchitects/auth-angular/state';
+
+export const appProviders = [...provideAuthConfig({ apiResourcePath: 'auth' }), ...provideAuthState()];
+```
+
+Custom profile:
+
+```ts
+import { provideAuthConfig, provideAuthContracts } from '@anarchitects/auth-angular/config';
+import { provideAuthState } from '@anarchitects/auth-angular/state';
+
+export const appProviders = [
+  ...provideAuthConfig({ apiResourcePath: 'auth' }),
+  ...provideAuthContracts({
+    register: {
+      name: {
+        required: true,
+        minLength: 3,
+        emptyStringPolicy: 'strip',
+      },
+    },
+  }),
+  ...provideAuthState(),
+];
+```
+
+Effects of that provider:
+
+- auth form components render required/minLength/maxLength from the profile
+- pre-submit payload shaping uses the same `emptyStringPolicy`
+- `AuthStore` remains the submit boundary; UI components still emit raw DTOs
+
+## Version Compatibility
+
+Contract profiles carry a `version` field and compatibility checks are exact today.
+
+- Pin the version you expect with `assertContractCompatibility(...)`.
+- Treat stricter constraints as breaking changes.
+- Update consumers intentionally when a profile version changes.
+
+## Migration Checklist
+
+1. Keep DTO type imports such as `LoginRequestDTO` unless you need custom runtime behavior.
+2. Stop treating fixed `*RequestSchema` exports as the customization seam.
+3. Build custom runtime/form behavior from `createAuthContracts(...)`.
+4. Pass backend overrides through `AuthModule.forRoot({ contracts })` or `AuthModule.forRootFromConfig({ contracts })`.
+5. Pass frontend overrides through `provideAuthContracts(...)`.
+6. Regenerate and diff OpenAPI after schema-impacting changes:
+   - `yarn nx run api-specs:generate`
+   - `yarn nx run api-specs:lint`
+   - `yarn nx run api-specs:diff`
+7. Re-validate the docs hub when README or guide content changes:
+   - `yarn nx run docs-hub:validate-content`
+   - `yarn nx run docs-hub:build`
+   - `yarn nx run docs-hub:verify`

--- a/libs/auth/angular/README.md
+++ b/libs/auth/angular/README.md
@@ -3,6 +3,7 @@
 Angular domain libraries for the Anarchitecture auth domain. The package is organized into standalone slices (config, data-access, feature, state, util, ui) that compose implementation-aligned authentication flows for Angular applications.
 
 Migration guidance for the Better Auth realignment lives in the [auth migration guide](../../../docs/guides/auth-migration.md).
+Migration guidance for the contract-driven auth profile model lives in the [auth contract migration guide](../../../docs/guides/auth-contracts-migration.md).
 
 ## Developer + AI Agent Start Here
 
@@ -15,6 +16,7 @@ Migration guidance for the Better Auth realignment lives in the [auth migration 
 ## Features
 
 - `config`: DI tokens and provider helpers (API resource path, defaults)
+- `config`: DI tokens and provider helpers for auth contract profiles via `provideAuthContracts(...)`
 - `data-access`: generated OpenAPI clients plus adapters over the Nest API
 - `state`: signal-based store plus explicit provider helper for core session login/logout, eager session restore, and ability hydration
 - `feature`: coarse route guard, resource-aware route guard, and orchestration components that delegate rendering to auth UI components
@@ -54,7 +56,7 @@ The internal `@anarchitects/auth-ts`, `@anarchitects/forms-angular`, `@anarchite
 ```ts
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient, withFetch } from '@angular/common/http';
-import { provideAuthConfig } from '@anarchitects/auth-angular/config';
+import { provideAuthConfig, provideAuthContracts } from '@anarchitects/auth-angular/config';
 import { provideAuthState } from '@anarchitects/auth-angular/state';
 
 export const appConfig: ApplicationConfig = {
@@ -63,6 +65,7 @@ export const appConfig: ApplicationConfig = {
     ...provideAuthConfig({
       apiResourcePath: 'auth',
     }),
+    ...provideAuthContracts(),
     ...provideAuthState(),
   ],
 };
@@ -92,18 +95,14 @@ export class AppComponent {
 ```ts
 // app.routes.ts
 import { Routes } from '@angular/router';
-import {
-  policyGuard,
-  resourcePolicyGuard,
-} from '@anarchitects/auth-angular/feature';
+import { policyGuard, resourcePolicyGuard } from '@anarchitects/auth-angular/feature';
 
 export const routes: Routes = [
   {
     path: 'admin',
     canMatch: [policyGuard],
     data: { action: 'manage', subject: 'admin-section' },
-    loadComponent: () =>
-      import('./admin.component').then((m) => m.AdminComponent),
+    loadComponent: () => import('./admin.component').then((m) => m.AdminComponent),
   },
   {
     path: 'posts/:postId/edit',
@@ -115,13 +114,90 @@ export const routes: Routes = [
       resourceKey: 'post',
       unauthorizedRedirectTo: '/posts',
     },
-    loadComponent: () =>
-      import('./post-edit.component').then((m) => m.PostEditComponent),
+    loadComponent: () => import('./post-edit.component').then((m) => m.PostEditComponent),
   },
 ];
 ```
 
 `policyGuard` is a coarse route-attempt guard. It answers "may this user attempt work on this subject at all?" by using the shared route matcher from `@anarchitects/auth-ts`. Concrete ownership checks still belong to loaded resources. Use `resourcePolicyGuard` for resolved edit/detail routes and `canAccessResource(...)` / `canAccessResourceField(...)` for UI elements such as edit buttons.
+
+### Contract-driven auth forms
+
+`@anarchitects/auth-angular` uses the same auth contract profile for rendered form rules and submit-time payload shaping.
+
+- `provideAuthContracts(...)` supplies a profile override at app or feature scope.
+- The UI form components read the resolved contract metadata through DI.
+- `AuthStore` shapes outgoing payloads from the same contract profile before calling `AuthApi`.
+
+Example: require a register name, make login passwords optional, and strip empty optional names before submit.
+
+```ts
+import { ApplicationConfig } from '@angular/core';
+import { provideAuthContracts } from '@anarchitects/auth-angular/config';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    ...provideAuthContracts({
+      register: {
+        name: {
+          required: true,
+          minLength: 3,
+          emptyStringPolicy: 'strip',
+        },
+      },
+      login: {
+        password: {
+          required: false,
+        },
+      },
+    }),
+  ],
+};
+```
+
+The auth UI components consume that profile automatically:
+
+```ts
+import { Component } from '@angular/core';
+import { AnarchitectsAuthUiRegisterForm } from '@anarchitects/auth-angular/ui';
+
+@Component({
+  selector: 'app-register-page',
+  imports: [AnarchitectsAuthUiRegisterForm],
+  template: `<anarchitects-auth-ui-register-form />`,
+})
+export class RegisterPageComponent {}
+```
+
+If you need the resolved contract object directly, use `injectAuthContracts()` from `@anarchitects/auth-angular/config`.
+
+### Payload shaping
+
+Submit raw DTOs from components and let `AuthStore` apply the profile's `emptyStringPolicy` rules before the HTTP call.
+
+```ts
+import { Component, inject } from '@angular/core';
+import { AuthStore } from '@anarchitects/auth-angular/state';
+
+@Component({
+  selector: 'app-register-action',
+  template: `<button type="button" (click)="register()">Register</button>`,
+})
+export class RegisterActionComponent {
+  private readonly authStore = inject(AuthStore);
+
+  register() {
+    this.authStore.registerUser({
+      name: '',
+      email: 'jane@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+    });
+  }
+}
+```
+
+With a contract such as `register.name.required = false` plus `emptyStringPolicy = 'strip'`, the store omits `name` from the outgoing request body instead of sending `name: ''`.
 
 ### Optional JWT plugin wiring
 
@@ -133,10 +209,7 @@ import { withJwtAuthHttpInterceptors } from '@anarchitects/auth-angular/data-acc
 import { provideAuthJwtState } from '@anarchitects/auth-angular/state/jwt';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideHttpClient(withJwtAuthHttpInterceptors()),
-    ...provideAuthJwtState(),
-  ],
+  providers: [provideHttpClient(withJwtAuthHttpInterceptors()), ...provideAuthJwtState()],
 };
 ```
 
@@ -144,10 +217,7 @@ Blog ownership example:
 
 ```ts
 import { Component, computed, inject, input } from '@angular/core';
-import {
-  canAccessResource,
-  canAccessResourceField,
-} from '@anarchitects/auth-angular/util';
+import { canAccessResource, canAccessResourceField } from '@anarchitects/auth-angular/util';
 import { AuthStore } from '@anarchitects/auth-angular/state';
 
 @Component({
@@ -165,41 +235,26 @@ export class PostActionsComponent {
   readonly post = input.required<{ id: string; authorId: string }>();
   private readonly authStore = inject(AuthStore);
 
-  readonly canEdit = computed(() =>
-    canAccessResource(
-      this.authStore.ability(),
-      'update',
-      'Post',
-      this.post(),
-    ),
-  );
+  readonly canEdit = computed(() => canAccessResource(this.authStore.ability(), 'update', 'Post', this.post()));
 
-  readonly canEditTitle = computed(() =>
-    canAccessResourceField(
-      this.authStore.ability(),
-      'update',
-      'Post',
-      'title',
-      this.post(),
-    ),
-  );
+  readonly canEditTitle = computed(() => canAccessResourceField(this.authStore.ability(), 'update', 'Post', 'title', this.post()));
 }
 ```
 
 ## Entry points
 
-| Import path                              | Description                             |
-| ---------------------------------------- | --------------------------------------- |
-| `@anarchitects/auth-angular/config`           | DI tokens and providers                           |
-| `@anarchitects/auth-angular/data-access`      | Generated API clients and HTTP adapters           |
-| `@anarchitects/auth-angular/data-access/jwt`  | JWT plugin APIs and interceptor helpers           |
-| `@anarchitects/auth-angular/state`            | Signal store, eager restore, CASL ability sync    |
-| `@anarchitects/auth-angular/state/jwt`        | JWT refresh-token state orchestration             |
-| `@anarchitects/auth-angular/feature`          | Coarse and resource-aware router guards           |
-| `@anarchitects/auth-angular/feature/jwt`      | JWT refresh-token orchestration components         |
-| `@anarchitects/auth-angular/ui`               | Auth domain form UI components                    |
-| `@anarchitects/auth-angular/ui/jwt`           | JWT refresh-token form components                 |
-| `@anarchitects/auth-angular/util`             | CASL ability/resource helpers and typings         |
+| Import path                                  | Description                                    |
+| -------------------------------------------- | ---------------------------------------------- |
+| `@anarchitects/auth-angular/config`          | DI tokens and providers                        |
+| `@anarchitects/auth-angular/data-access`     | Generated API clients and HTTP adapters        |
+| `@anarchitects/auth-angular/data-access/jwt` | JWT plugin APIs and interceptor helpers        |
+| `@anarchitects/auth-angular/state`           | Signal store, eager restore, CASL ability sync |
+| `@anarchitects/auth-angular/state/jwt`       | JWT refresh-token state orchestration          |
+| `@anarchitects/auth-angular/feature`         | Coarse and resource-aware router guards        |
+| `@anarchitects/auth-angular/feature/jwt`     | JWT refresh-token orchestration components     |
+| `@anarchitects/auth-angular/ui`              | Auth domain form UI components                 |
+| `@anarchitects/auth-angular/ui/jwt`          | JWT refresh-token form components              |
+| `@anarchitects/auth-angular/util`            | CASL ability/resource helpers and typings      |
 
 ## Nx scripts
 

--- a/libs/auth/nest/README.md
+++ b/libs/auth/nest/README.md
@@ -3,6 +3,7 @@
 NestJS services, controllers, and infrastructure for the Anarchitecture authentication domain. This package wires contract-driven DTOs from `@anarchitects/auth-ts`, uses Better Auth as the canonical internal auth engine, keeps email/password always enabled, and layers repo-owned RBAC on top of Better Auth-backed user/session state.
 
 Migration guidance for the Better Auth realignment lives in the [auth migration guide](../../../docs/guides/auth-migration.md).
+Migration guidance for the contract-driven auth profile model lives in the [auth contract migration guide](../../../docs/guides/auth-contracts-migration.md).
 
 ## Developer + AI Agent Start Here
 
@@ -149,6 +150,15 @@ export class AppModule {}
 
 ## Usage
 
+### Contract-driven route validation
+
+`@anarchitects/auth-nest` now resolves request-body validation from an auth contract profile at module bootstrap.
+
+- If you omit `contracts`, the module uses `DefaultAuthContractConfig`.
+- Pass explicit overrides with `AuthModule.forRoot({ contracts: ... })` for deterministic app-local configuration.
+- Pass explicit overrides with `AuthModule.forRootFromConfig({ contracts: ... })` when the rest of the module is config-driven but the contract profile still needs code-level control.
+- `forRootFromConfig(...)` intentionally overlays explicit `contracts` overrides onto the default profile today; there is no dedicated `AUTH_*` contract env tree yet.
+
 ### Easy mode (single facade import)
 
 ```ts
@@ -208,6 +218,16 @@ AuthModule.forRootFromConfig({
   },
 });
 ```
+
+The same contract profile drives Fastify request validation for the core auth routes:
+
+- `POST /auth/register`
+- `POST /auth/login`
+- `POST /auth/logout`
+- `POST /auth/forgot-password`
+- `POST /auth/reset-password`
+- `POST /auth/verify-email`
+- `PATCH /auth/change-password/:userId`
 
 Disable domain mailer wiring when not needed:
 

--- a/libs/auth/ts/README.md
+++ b/libs/auth/ts/README.md
@@ -5,10 +5,12 @@ TypeScript DTOs and domain models for the Anarchitecture authentication stack. T
 - Implementation-driven request/response schemas authored with [TypeBox](https://github.com/sinclairzx81/typebox)
 - Type-safe DTO aliases consumed by Angular and Nest libraries and reflected in generated OpenAPI docs
 - Domain models (`User`, `Role`, `Permission`) for composing dynamic RBAC logic across services
+- Contract-driven auth profile factories that generate backend request schemas and frontend form metadata from one config
 
 Use it to validate inbound/outbound payloads, share typings between Angular/Nest bricks, and keep auth-specific logic consistent across tiers.
 
 Migration guidance for the Better Auth realignment lives in the [auth migration guide](../../../docs/guides/auth-migration.md).
+Migration guidance for the contract-driven auth profile model lives in the [auth contract migration guide](../../../docs/guides/auth-contracts-migration.md).
 
 ## Developer + AI Agent Start Here
 
@@ -22,6 +24,7 @@ Migration guidance for the Better Auth realignment lives in the [auth migration 
 - Centralized TypeBox DTO schemas shared by Angular and Nest stacks
 - Domain model contracts for users, roles, and permissions
 - Reusable validation + type-inference building blocks for auth flows
+- Contract profile config, compatibility checks, and schema factories for runtime/frontend alignment
 
 ## Authorization Contract
 
@@ -60,12 +63,67 @@ pnpm add @anarchitects/auth-ts
 
 ## Entry points
 
-| Import path                      | Description                                                        |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `@anarchitects/auth-ts`          | Barrel re-export for core models plus the core/session DTO surface |
-| `@anarchitects/auth-ts/dtos`     | Core/session request-response schemas and DTO types (TypeBox)      |
-| `@anarchitects/auth-ts/dtos/jwt` | JWT plugin-specific DTO types and schemas                          |
-| `@anarchitects/auth-ts/models`   | Domain models used for user/session/RBAC composition               |
+| Import path                       | Description                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------- |
+| `@anarchitects/auth-ts`           | Barrel re-export for core models plus the core/session DTO surface                    |
+| `@anarchitects/auth-ts/contracts` | Contract profile config, schema factories, compatibility helpers, and payload shaping |
+| `@anarchitects/auth-ts/dtos`      | Core/session request-response schemas and DTO types (TypeBox)                         |
+| `@anarchitects/auth-ts/dtos/jwt`  | JWT plugin-specific DTO types and schemas                                             |
+| `@anarchitects/auth-ts/models`    | Domain models used for user/session/RBAC composition                                  |
+
+## Contract Profiles
+
+`@anarchitects/auth-ts` is the source of truth for contract-driven auth behavior across Nest and Angular.
+
+- `AuthContractConfig` defines the profile shape for register, login, forgot-password, reset-password, verify-email, change-password, and logout.
+- `DefaultAuthContractConfig` is the published default profile.
+- `createAuthContracts(config)` derives request schemas and form metadata from one profile.
+- `assertContractCompatibility(config, expectedVersion)` fails fast when a consumer expects a different profile version.
+
+Use the factory whenever you need a custom auth profile or want one object that drives both runtime validation and UI behavior:
+
+```ts
+import { DefaultAuthContractConfig, assertContractCompatibility, createAuthContracts } from '@anarchitects/auth-ts';
+
+assertContractCompatibility(DefaultAuthContractConfig, '1.0.0');
+
+const contracts = createAuthContracts(DefaultAuthContractConfig);
+
+contracts.registerRequestSchema;
+contracts.registerFormMeta.name.required;
+contracts.changePasswordFormMeta.newPassword.minLength;
+```
+
+Custom profiles are built by copying the default profile and overriding only the fields you want to change:
+
+```ts
+import { type AuthContractConfig, DefaultAuthContractConfig, createAuthContracts } from '@anarchitects/auth-ts';
+
+const productProfile: AuthContractConfig = {
+  ...DefaultAuthContractConfig,
+  version: '1.0.0',
+  register: {
+    ...DefaultAuthContractConfig.register,
+    name: {
+      ...DefaultAuthContractConfig.register.name,
+      required: true,
+      minLength: 3,
+      emptyStringPolicy: 'strip',
+    },
+  },
+  login: {
+    ...DefaultAuthContractConfig.login,
+    password: {
+      ...DefaultAuthContractConfig.login.password,
+      minLength: 10,
+    },
+  },
+};
+
+const contracts = createAuthContracts(productProfile);
+```
+
+The static DTO schema exports such as `RegisterRequestSchema` and `LoginRequestSchema` remain available as default-profile convenience helpers. When a consumer needs profile customization, switch from those fixed exports to `createAuthContracts(...)`.
 
 ## Usage
 
@@ -73,10 +131,7 @@ pnpm add @anarchitects/auth-ts
 
 ```ts
 import { Value } from '@sinclair/typebox/value';
-import {
-  LoginRequestSchema,
-  LoginRequestDTO,
-} from '@anarchitects/auth-ts/dtos';
+import { LoginRequestSchema, LoginRequestDTO } from '@anarchitects/auth-ts/dtos';
 
 const payload: LoginRequestDTO = {
   credential: 'user@example.com',
@@ -95,9 +150,7 @@ if (errors.length > 0) {
 > import { FormatRegistry } from '@sinclair/typebox';
 >
 > FormatRegistry.Set('email', (value: unknown): value is string => {
->   return (
->     typeof value === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
->   );
+>   return typeof value === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 > });
 > ```
 
@@ -108,16 +161,18 @@ import { User, Role, Permission } from '@anarchitects/auth-ts/models';
 
 function can(user: User, action: string, subject: string): boolean {
   const roles: Role[] = user.roles ?? [];
-  return roles.some((role) =>
-    (role.permissions ?? []).some(
-      (permission: Permission) =>
-        permission.action === action && permission.subject === subject,
-    ),
-  );
+  return roles.some((role) => (role.permissions ?? []).some((permission: Permission) => permission.action === action && permission.subject === subject));
 }
 ```
 
 The models include timestamps (`createdAt`, `updatedAt`) and bidirectional relationships to support dynamic RBAC composition in persistence layers.
+
+### Contract profile versioning
+
+- Contract profiles carry their own `version` field.
+- Compatibility checks are exact today: `assertContractCompatibility(...)` compares the expected and actual version strings directly.
+- Treat stricter default-profile changes as breaking changes. Examples: raising `minLength`, lowering `maxLength`, or changing a field from optional to required.
+- Consumers should pin the profile version they expect and update intentionally when contract constraints change.
 
 ## Scripts
 

--- a/tools/api-specs/diff.ts
+++ b/tools/api-specs/diff.ts
@@ -5,6 +5,19 @@ import { join } from 'node:path';
 import OpenApiDiff from 'openapi-diff';
 
 const SPEC_PATH = join(process.cwd(), 'docs/openapi/openapi.yaml');
+const OPENAPI_31_REGEX = /^openapi:\s*["']?3\.1\.\d+["']?\s*$/m;
+
+function normalizeSpecForDiff(content: string, label: string): string {
+  if (!OPENAPI_31_REGEX.test(content)) {
+    return content;
+  }
+
+  console.log(
+    `Normalizing ${label} OpenAPI version from 3.1.x to 3.0.3 for openapi-diff compatibility.`,
+  );
+
+  return content.replace(OPENAPI_31_REGEX, 'openapi: 3.0.3');
+}
 
 function loadCurrentSpec(): string {
   return readFileSync(SPEC_PATH, 'utf8');
@@ -40,15 +53,20 @@ async function run() {
   }
 
   const destination = loadCurrentSpec();
+  const normalizedSource = normalizeSpecForDiff(source, `${baseRef} spec`);
+  const normalizedDestination = normalizeSpecForDiff(
+    destination,
+    'workspace spec',
+  );
 
   const result = await OpenApiDiff.diffSpecs({
     sourceSpec: {
-      content: source,
+      content: normalizedSource,
       location: `${baseRef}:docs/openapi/openapi.yaml`,
       format: 'openapi3',
     },
     destinationSpec: {
-      content: destination,
+      content: normalizedDestination,
       location: 'workspace/docs/openapi/openapi.yaml',
       format: 'openapi3',
     },


### PR DESCRIPTION
Document the contract-driven auth profile model across auth-ts, auth-nest, and auth-angular, add a dedicated migration guide for moving from fixed DTO schemas to generated contract profiles, and update contributing guidance for OpenAPI diff checks on contract changes.

Also normalize OpenAPI 3.1 specs to 3.0.3 inside the diff tool so `api-specs:diff` can compare current and base specs without parser failures.

Closes #260 Refs #248