### PR TITLE
docs(architecture): align 3-tier repo with bricks-ddd companion repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ You are an engineering assistant for an Nx monorepo containing reusable librarie
 13. Prefer documenting and using root facade modules (`@anarchitects/<domain>-nest`) in quick starts; use secondary entry points for advanced composition/overrides.
 14. Configure shared infrastructure transports once at app root (for example mail transport via `CommonMailerModule`) and keep domain infrastructure modules adapter-only wrappers over shared implementations (for example `CommonNodeMailerModule`).
 15. When domain infrastructure is optional, expose facade-level feature flags (for example `features.mailer`) and provide safe no-op behavior for disabled features.
+16. Keep this repo aligned with `anarchitects/anarchitecture-bricks-ddd` at the domain and capability level, while preserving the 3-tier implementation style in this repo.
+17. Treat migration from 3-tier structure to DDD structure as a supported evolution path.
 
 ## Library API Paradigm (Maximum Flexibility + Ease of Use)
 
@@ -89,6 +91,14 @@ You are an engineering assistant for an Nx monorepo containing reusable librarie
   - quick start via facade/easy mode.
   - advanced composition via secondary entry points.
   - deterministic behavior checks for both `forRoot` and `forRootFromConfig`.
+
+## Cross-Repo Alignment Standards
+
+For alignment with the DDD companion repo and migration expectations, follow:
+
+- `docs/guides/alignment-with-bricks-ddd.md`
+- `docs/guides/migration-to-bricks-ddd.md`
+- `docs/adr/0001-align-with-bricks-ddd-and-support-migration.md`
 
 ## Preferred Commands
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Modular, reusable libraries and showcase applications for scalable software arch
 - Technical docs generated with Compodoc and surfaced through Storybook.
 - Nx-managed example applications in `examples/` for integration and contract validation.
 
+## Companion Repo Position
+
+This repository is the 3-tier companion to:
+
+- `anarchitects/anarchitecture-bricks-ddd`
+
+The two repos should align on domain intent and public capability surface, while differing in internal architectural style.
+
 ## Source of Truth
 
 1. Shared model and DTO schemas: `libs/*/ts`.
@@ -65,6 +73,8 @@ examples/
 
 docs/
   openapi/
+  guides/
+  adr/
 
 tools/
   api-specs/
@@ -157,6 +167,28 @@ If local dry-runs are needed, use the repo runner, for example `yarn nx run rele
 - Keep precedence consistent when both inputs exist: explicit overrides > config-derived values > hardcoded defaults.
 - Mail transport setup should be centralized once at app root via `@anarchitects/common-nest-mailer` (`CommonMailerModule.forRootFromConfig()` or `forRootAsync(...)`), while domain infrastructure-mailer entry points remain thin wrappers over shared provider wiring via `CommonMailerModule.forRoot(...)`.
 - Domain facade modules should expose mailer provider controls (for example `mailer.provider`) so infrastructure adapters can be composed per domain without changing root mail transport setup.
+
+## Cross-Repo Alignment Position
+
+This repository should stay aligned with `anarchitecture-bricks-ddd` at the domain/capability level.
+
+Alignment means:
+
+- comparable domain intent
+- comparable public capability surface
+- traceable mapping between 3-tier packages and DDD package families
+- documented migration paths from 3-tier structure to DDD structure
+
+Alignment does **not** mean identical file structure or forced architectural sameness.
+
+## Architecture Guides
+
+- [Guide: Alignment With `anarchitecture-bricks-ddd`](docs/guides/alignment-with-bricks-ddd.md)
+- [Guide: Migration To `anarchitecture-bricks-ddd`](docs/guides/migration-to-bricks-ddd.md)
+
+## Architecture Decision Records
+
+- [ADR-0001: Align With `anarchitecture-bricks-ddd` And Support Migration](docs/adr/0001-align-with-bricks-ddd-and-support-migration.md)
 
 ## Documentation Tooling
 

--- a/docs/adr/0001-align-with-bricks-ddd-and-support-migration.md
+++ b/docs/adr/0001-align-with-bricks-ddd-and-support-migration.md
@@ -1,0 +1,84 @@
+# ADR-0001: Align With `anarchitecture-bricks-ddd` And Support Migration
+
+- Status: Accepted
+- Date: 2026-04-23
+- Owners: Architecture maintainers
+- Context: `anarchitecture-bricks-3tier` and `anarchitecture-bricks-ddd` are companion repositories with different internal architectural styles
+
+## Context
+
+This repository and `anarchitecture-bricks-ddd` are intended to evolve as companion repositories.
+
+They should not become literal copies of one another, but they also must not drift into unrelated products.
+
+We need an explicit decision that:
+
+- defines the relationship between the 3-tier and DDD repos
+- clarifies what should align between them
+- treats migration from 3-tier to DDD as a supported evolution path
+
+## Decision
+
+### Companion repo posture
+
+`anarchitecture-bricks-3tier` and `anarchitecture-bricks-ddd` are companion repositories.
+
+They should align on:
+
+- bounded-context/domain intent
+- public capability surface by domain
+- contract ownership and domain language
+- example-app use cases where practical
+
+They may differ on:
+
+- internal package structure
+- internal layering granularity
+- explicitness of ports/adapters and DDD boundaries
+
+### Architectural distinction
+
+This repository remains the 3-tier companion implementation style.
+
+The DDD repo remains the DDD/hexagonal companion implementation style.
+
+Neither repo is a mere copy of the other.
+
+### Migration posture
+
+Migration from 3-tier to DDD is a supported path.
+
+That migration should preserve domain meaning and public capability while translating structure from:
+
+- shared `ts`
+- domain-level Angular package
+- domain-level Nest package
+
+into the more explicit DDD package families.
+
+## Consequences
+
+### Positive
+
+- cross-repo drift becomes easier to detect
+- the two repos can evolve coherently without forced sameness
+- migration to DDD becomes part of the documented architecture story
+- maintainers get a clear mapping model between the repos
+
+### Trade-offs
+
+- maintainers must document intentional divergence explicitly
+- some domains may need structural translation rather than direct copy/move operations
+- cross-repo parity requires ongoing discipline
+
+## Rules Derived From This Decision
+
+1. New or changed domains in this repo should consider their counterpart in `anarchitecture-bricks-ddd`.
+2. Capability alignment matters more than path-level sameness.
+3. Migration to DDD should separate business meaning from transport/contracts and split frontend/backend responsibilities more explicitly.
+4. Silent conceptual drift between the repos is not acceptable.
+
+## Related
+
+- [Guide: Alignment With `anarchitecture-bricks-ddd`](../guides/alignment-with-bricks-ddd.md)
+- [Guide: Migration To `anarchitecture-bricks-ddd`](../guides/migration-to-bricks-ddd.md)

--- a/docs/guides/alignment-with-bricks-ddd.md
+++ b/docs/guides/alignment-with-bricks-ddd.md
@@ -1,0 +1,176 @@
+# Alignment With `anarchitecture-bricks-ddd`
+
+- Status: Active guide
+- Audience: Maintainers and contributors of `anarchitecture-bricks-3tier`
+- Scope: Cross-repo alignment with `anarchitects/anarchitecture-bricks-ddd`
+
+## Purpose
+
+`anarchitecture-bricks-3tier` and `anarchitecture-bricks-ddd` are companion repositories.
+
+They must **sensibly mirror each other** at the bounded-context and capability level, while **not** becoming literal copies of one another.
+
+The goal is:
+
+- the same business capabilities and domain areas remain recognizable across both repos
+- the 3-tier repo provides the 3-tier implementation style
+- the DDD repo provides the DDD/hexagonal implementation style
+- migration from 3-tier to DDD remains practical, incremental, and well-documented
+
+## Core Position
+
+The two repos should align on:
+
+- bounded-context names and intent where possible
+- public capability surface by domain
+- contract ownership and domain language
+- example-app scenarios used to validate the libraries
+- documentation of how one style maps to the other
+
+The two repos should differ in:
+
+- internal architecture style
+- internal layering granularity
+- how responsibilities are packaged
+- how domain and contract boundaries are represented internally
+
+## What “Aligned” Means
+
+Alignment does **not** mean that every library path, class name, or entry point is identical.
+
+Alignment means that a maintainer can answer these questions clearly across both repos:
+
+1. Which bounded context in 3-tier corresponds to which bounded context in DDD?
+2. Which public capabilities are intentionally equivalent?
+3. How does a 3-tier implementation map to the more explicit DDD structure?
+4. What is the migration path if a domain should move from 3-tier packaging to DDD packaging?
+
+## Repository Relationship
+
+### `anarchitecture-bricks-3tier`
+
+This repo is the companion implementation style for:
+
+- reusable libraries organized in a simpler 3-tier structure
+- TypeScript shared schemas/models in `libs/<domain>/ts`
+- Angular and Nest deliverables organized per domain without the full DDD package split
+
+### `anarchitecture-bricks-ddd`
+
+The DDD repo is the companion implementation style for:
+
+- reusable libraries organized by bounded context, technology family, and explicit layer
+- shared TS core split into `ts/domain` and `ts/contracts`
+- more explicit ports/adapters and application-layer boundaries
+
+## Canonical Mapping Model
+
+Use this mapping model when documenting or implementing equivalent capabilities.
+
+### Shared TS
+
+3-tier:
+
+- `libs/<domain>/ts`
+
+DDD:
+
+- `libs/<context>/ts/domain`
+- `libs/<context>/ts/contracts`
+
+Interpretation:
+
+- the 3-tier TS library often contains concerns that the DDD repo splits into domain and contract packages
+- migration should separate business meaning from transport/public schemas intentionally
+
+### Nest
+
+3-tier:
+
+- `libs/<domain>/nest`
+
+DDD:
+
+- `libs/<context>/nest/application`
+- `libs/<context>/nest/presentation`
+- `libs/<context>/nest/infrastructure-*`
+- `libs/<context>/nest/facade`
+
+Interpretation:
+
+- the 3-tier Nest package corresponds to multiple DDD Nest layer packages
+- the DDD repo makes ports, adapters, and composition roots more explicit
+
+### Angular
+
+3-tier:
+
+- `libs/<domain>/angular`
+
+DDD:
+
+- `libs/<context>/angular/ui`
+- `libs/<context>/angular/feature`
+- `libs/<context>/angular/state`
+- `libs/<context>/angular/data-access`
+- `libs/<context>/angular/facade`
+
+Interpretation:
+
+- the 3-tier Angular package corresponds to multiple explicit frontend layers in the DDD repo
+- both repos should still align on the same frontend capability surface per domain
+
+## Alignment Rules
+
+### 1. Keep bounded-context/domain names intentionally close
+
+If a capability exists in one repo, the corresponding capability in the other repo should use the same or clearly traceable naming.
+
+### 2. Keep public language aligned
+
+DTO names, public concepts, and package-level terminology should not drift casually between repos.
+
+### 3. Keep examples comparable
+
+If `auth` or `forms` exists in both repos, the example applications should validate comparable use cases, even if the internal implementation style differs.
+
+### 4. Do not force artificial sameness
+
+The DDD repo is allowed to be more explicit and more granular. The 3-tier repo is allowed to remain simpler. Alignment should preserve intent, not erase the difference in architectural style.
+
+### 5. Document drift explicitly
+
+If one repo intentionally moves ahead of the other for a domain or capability, document the divergence instead of letting it become silent drift.
+
+## Preferred Evolution Pattern
+
+When a domain starts in 3-tier but needs stronger domain boundaries, the preferred path is:
+
+1. preserve the domain name and public intent
+2. identify business meaning vs transport/schema concerns in `libs/<domain>/ts`
+3. map Nest concerns into application, presentation, infrastructure, and facade responsibilities
+4. map Angular concerns into `ui`, `feature`, `state`, `data-access`, and `facade`
+5. document the migration in both repos
+
+## Anti-Patterns
+
+Avoid the following:
+
+- letting the same domain mean different things in the two repos
+- copying files mechanically from one repo to the other without architectural translation
+- treating the DDD repo as merely a renamed 3-tier repo
+- treating the 3-tier repo as obsolete or architecturally invalid by default
+- introducing new domains in one repo without at least documenting the expected counterpart in the other
+
+## Checklist
+
+Before adding or changing a domain in this repo, verify:
+
+1. Does the corresponding domain or bounded context exist in `anarchitecture-bricks-ddd`?
+2. If yes, is the intent still aligned?
+3. If no, should a counterpart be created later, or is the divergence intentional?
+4. If this change would complicate future migration to DDD, is that trade-off acceptable and documented?
+
+## Related
+
+- [Guide: Migration To `anarchitecture-bricks-ddd`](./migration-to-bricks-ddd.md)

--- a/docs/guides/migration-to-bricks-ddd.md
+++ b/docs/guides/migration-to-bricks-ddd.md
@@ -1,0 +1,182 @@
+# Migration To `anarchitecture-bricks-ddd`
+
+- Status: Active guide
+- Audience: Maintainers planning or executing migration from `anarchitecture-bricks-3tier` to `anarchitecture-bricks-ddd`
+- Scope: Domain-by-domain and layer-by-layer migration from 3-tier structure to DDD structure
+
+## Purpose
+
+This guide describes how to migrate capabilities from the 3-tier repo to the DDD repo.
+
+The migration goal is **not** to copy code mechanically. The goal is to preserve domain meaning and public capability while translating the implementation into the more explicit DDD structure.
+
+## Core Principle
+
+Migrate **architecture structure**, not **business meaning**.
+
+A successful migration preserves:
+
+- the same bounded-context/domain intent
+- the same or intentionally evolved public language
+- the same capability surface where appropriate
+- the same example use cases where practical
+
+What changes is the internal structure and separation of responsibilities.
+
+## Canonical Structural Mapping
+
+### Shared TS
+
+From 3-tier:
+
+- `libs/<domain>/ts`
+
+To DDD:
+
+- `libs/<context>/ts/domain`
+- `libs/<context>/ts/contracts`
+
+Migration question:
+
+- which parts of the 3-tier TS package are business model concerns?
+- which parts are transport/public schema concerns?
+
+### Nest
+
+From 3-tier:
+
+- `libs/<domain>/nest`
+
+To DDD:
+
+- `libs/<context>/nest/application`
+- `libs/<context>/nest/presentation`
+- `libs/<context>/nest/infrastructure-*`
+- `libs/<context>/nest/facade`
+
+Migration question:
+
+- which code is orchestration/use-case logic?
+- which code is controller/presentation?
+- which code is persistence/integration adapter logic?
+- which code is easy-mode composition?
+
+### Angular
+
+From 3-tier:
+
+- `libs/<domain>/angular`
+
+To DDD:
+
+- `libs/<context>/angular/ui`
+- `libs/<context>/angular/feature`
+- `libs/<context>/angular/state`
+- `libs/<context>/angular/data-access`
+- `libs/<context>/angular/facade`
+
+Migration question:
+
+- which code is presentational?
+- which code is smart composition?
+- which code is state/orchestration?
+- which code is transport/integration?
+
+## Recommended Migration Sequence
+
+### Step 1: confirm the target bounded context
+
+Before migrating, confirm that the 3-tier domain maps cleanly to one target bounded context in the DDD repo.
+
+If not, decide whether:
+
+- the 3-tier domain should split into multiple bounded contexts
+- the 3-tier domain should remain one bounded context with cleaner internal boundaries
+
+### Step 2: split TS concerns first
+
+Start by separating:
+
+- domain meaning
+- public transport/contracts
+
+This is usually the most important structural change because the DDD repo treats those as separate first-class packages.
+
+### Step 3: extract Nest layer responsibilities
+
+Inside the 3-tier Nest package, identify:
+
+- application/use-case logic
+- presentation/controller concerns
+- infrastructure adapters
+- facade/composition logic
+
+Move these into the DDD Nest package family.
+
+### Step 4: extract Angular layer responsibilities
+
+Inside the 3-tier Angular package, identify:
+
+- `ui`
+- `feature`
+- `state`
+- `data-access`
+- `facade`
+
+Do not migrate the Angular package as one undifferentiated unit.
+
+### Step 5: preserve public capability parity
+
+After the structural migration, verify that the target DDD packages still represent the same domain capability intentionally.
+
+### Step 6: validate with comparable examples
+
+Use or create example flows that prove the migrated DDD bounded context still supports the equivalent use cases.
+
+## Incremental Migration Strategy
+
+Preferred strategy:
+
+- migrate one domain/bounded context at a time
+- migrate TS meaning/contracts first
+- migrate Nest and Angular in slices
+- keep both repos documented during overlap
+
+Avoid trying to rewrite the whole repo family in one move.
+
+## Practical Checklist
+
+For each migrating domain, answer:
+
+1. What is the target bounded-context name in the DDD repo?
+2. What in `libs/<domain>/ts` becomes `ts/domain`?
+3. What in `libs/<domain>/ts` becomes `ts/contracts`?
+4. Which Nest code becomes `application`?
+5. Which Nest code becomes `presentation`?
+6. Which Nest code becomes `infrastructure-*`?
+7. Which Angular code becomes `ui`, `feature`, `state`, and `data-access`?
+8. Which example use cases prove parity after migration?
+
+## Safe Migration Heuristics
+
+A 3-tier domain is a good candidate for DDD migration when:
+
+- business rules are becoming harder to isolate
+- DTO/schema concerns are mixed with domain meaning
+- Nest code is carrying multiple responsibilities in one package
+- Angular code is growing into a clear `ui`/`feature`/`state`/`data-access` split anyway
+- teams want more explicit ports/adapters and composition boundaries
+
+## Anti-Patterns
+
+Avoid:
+
+- copying the 3-tier TS package unchanged into `ts/domain`
+- moving all Nest code into one DDD layer and calling it migrated
+- moving all Angular code into `feature` and leaving `ui`/`state`/`data-access` empty
+- renaming without separating responsibilities
+- allowing the two repos to drift during migration without documenting equivalence
+
+## Related
+
+- [Guide: Alignment With `anarchitecture-bricks-ddd`](./alignment-with-bricks-ddd.md)


### PR DESCRIPTION
## Summary

Document the relationship between `anarchitecture-bricks-3tier` and `anarchitecture-bricks-ddd` from the 3-tier repo perspective.

## Changed

- added `docs/guides/alignment-with-bricks-ddd.md`
- added `docs/guides/migration-to-bricks-ddd.md`
- added `docs/adr/0001-align-with-bricks-ddd-and-support-migration.md`
- updated `README.md` to surface the companion repo relationship and migration guidance
- updated `AGENTS.md` to reference the cross-repo alignment standard

## What this covers

- companion repo posture
- what must align across the repos
- what may intentionally differ
- canonical mapping from 3-tier packages to DDD package families
- migration guidance from 3-tier structure to DDD structure

## Notes

This is a docs/ADR-only change set. It does not yet modify code, generators, or package structure.
