### PR TITLE
feat(skills): add repo-local ai skills

### DIFF
--- a/skills/bricks-3tier-implementation/SKILL.md
+++ b/skills/bricks-3tier-implementation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: bricks-3tier-implementation
+description: implement and refactor code in anarchitecture-bricks-3tier. use when work belongs specifically in the 3-tier bricks repo, especially for shared ts libraries, domain-level angular packages, domain-level nest packages, facade composition, openapi or compodoc or storybook documentation, and keeping the repo aligned with its ddd companion while preserving the 3-tier implementation style.
+---
+
+# Overview
+Use this skill when the task belongs in `anarchitecture-bricks-3tier`.
+
+Before changing code, inspect these repo files when relevant:
+
+- `AGENTS.md`
+- `README.md`
+- domain package `README.md` files
+- `docs/guides/alignment-with-bricks-ddd.md`
+- `docs/guides/migration-to-bricks-ddd.md`
+
+## Core implementation rules
+- Keep shared schemas, dto definitions, builders, and typed models in `libs/*/ts`.
+- Preserve the repo layering rules:
+  - Angular: `ui <- feature -> state -> data-access`
+  - Nest: `presentation -> application <- infrastructure`
+- Prefer root facade modules for easy mode, but preserve advanced subpath entry points.
+- Keep examples as validation surfaces, not product packages.
+- Do not create or modify anything under `apps/`.
+- Do not manually edit generated OpenAPI artifacts under `docs/openapi/`.
+
+## Required workflow
+1. Identify the target domain under `libs/<domain>`.
+2. Read the repo-level and package-level docs that govern the change.
+3. Implement the smallest change that satisfies the request while preserving the 3-tier style.
+4. Run or propose the correct Nx validation commands using the package-manager-prefixed form.
+5. In the final summary, call out whether the change affects cross-repo alignment with `anarchitecture-bricks-ddd`.
+
+## Nest-specific guidance
+- Keep route schemas imported from domain TS dto libraries.
+- Keep controller metadata compatible with OpenAPI generation.
+- Keep infrastructure wrappers thin and adapter-focused.
+- Preserve dual setup conventions such as `forRoot(...)` and `forRootFromConfig(...)` when they already exist.
+
+## Angular-specific guidance
+- Keep state intentionally scoped.
+- Do not introduce implicit root-scoped domain state.
+- Keep presentational concerns in `ui`, smart orchestration in `feature`, state in `state`, and transport in `data-access`.
+
+## Cross-repo alignment check
+When the change affects domain meaning, public capability, package naming, or migration expectations, also inspect:
+
+- `docs/guides/alignment-with-bricks-ddd.md`
+- `docs/guides/migration-to-bricks-ddd.md`
+- `docs/adr/0001-align-with-bricks-ddd-and-support-migration.md`
+
+If the requested change would make future migration to the DDD repo harder, say so explicitly.

--- a/skills/bricks-3tier-implementation/agents/openai.yaml
+++ b/skills/bricks-3tier-implementation/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: Bricks 3-Tier Implementation
+  short_description: Implement and refactor code in the 3-tier bricks repo while preserving repo conventions.

--- a/skills/monitor-ci/SKILL.md
+++ b/skills/monitor-ci/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: monitor-ci
+description: troubleshoot ci, workflow, build, test, lint, contract-test, docs, or release failures in anarchitecture-bricks-3tier. use when a github action, nx target, package publish flow, openapi check, compodoc or storybook build, or example-app validation fails and the task is specifically about diagnosing and fixing that repo without changing its architectural rules.
+---
+
+# Overview
+Use this skill when CI or repo automation is failing in `anarchitecture-bricks-3tier`.
+
+Inspect these sources first when relevant:
+
+- workflow logs and failed job output
+- `AGENTS.md`
+- `README.md`
+- the affected package `README.md`
+
+## Required workflow
+1. Identify the failing workflow, job, and Nx target.
+2. Reduce the failure to the smallest reproducible command.
+3. Fix the root cause, not just the symptom.
+4. Preserve repo architecture, release rules, and docs-generation conventions.
+5. Summarize the root cause, touched files, validation commands, and any remaining risk.
+
+## Repo-specific checks
+- Use package-manager-prefixed Nx commands.
+- Respect the docs-surface and release workflow rules already documented in the repo.
+- Do not “fix” OpenAPI or docs failures by editing generated artifacts directly.
+- Do not bypass module boundaries or simplify architecture just to make CI green.
+- If a failure is tied to cross-repo alignment with `anarchitecture-bricks-ddd`, mention that explicitly.
+
+## Output expectations
+When proposing or applying a fix, report:
+- failing target(s)
+- root cause
+- fix implemented
+- validation run or validation still needed
+- whether the fix could have breaking or release implications

--- a/skills/monitor-ci/agents/openai.yaml
+++ b/skills/monitor-ci/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: 3-Tier Monitor CI
+  short_description: Diagnose and fix CI, Nx, docs, and release failures in the 3-tier bricks repo.


### PR DESCRIPTION
## Summary

Add repo-local AI skills to `anarchitecture-bricks-3tier`.

## Added skills

- `skills/bricks-3tier-implementation`
- `skills/monitor-ci`

## Notes

These skills are repo-local and do not assume an MCP server exists yet.
They are intended to guide implementation and CI troubleshooting specifically for the 3-tier bricks repo.
