### PR TITLE
docs(architecture): codify audience-vs-capability library boundary rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ You are an engineering assistant for an Nx monorepo containing reusable librarie
 15. When domain infrastructure is optional, expose facade-level feature flags (for example `features.mailer`) and provide safe no-op behavior for disabled features.
 16. Keep this repo aligned with `anarchitects/anarchitecture-bricks-ddd` at the domain and capability level, while preserving the 3-tier implementation style in this repo.
 17. Treat migration from 3-tier structure to DDD structure as a supported evolution path.
+18. Do not split libraries by audience (`admin`, `public`, `backoffice`, etc.) as a default rule; package by capability first and introduce audience-specific libraries only when workflow divergence is real.
 
 ## Library API Paradigm (Maximum Flexibility + Ease of Use)
 
@@ -99,6 +100,7 @@ For alignment with the DDD companion repo and migration expectations, follow:
 - `docs/guides/alignment-with-bricks-ddd.md`
 - `docs/guides/migration-to-bricks-ddd.md`
 - `docs/adr/0001-align-with-bricks-ddd-and-support-migration.md`
+- `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md`
 
 ## Preferred Commands
 
@@ -457,3 +459,39 @@ Domain libraries **must never implicitly create global singleton state**.
 | Store registration | Use provider helpers                   |
 | App-wide state     | Register in app providers              |
 | Feature state      | Register in route or feature providers |
+
+## Audience vs Capability Packaging Convention
+
+Libraries should be split by audience only when workflow divergence is real.
+
+### Core Rule
+
+Do **not** create separate libraries such as `*-admin`, `*-public`, or `*-backoffice` merely because a consuming app places a feature behind a different route, layout, or guard.
+
+Prefer packaging by:
+
+- domain capability
+- layer responsibility
+- orchestration/workflow surface
+- reusable technical concern
+
+### Use Audience-Specific Libraries Only When
+
+A separate audience-specific library becomes justified when the workflow surface is genuinely different, for example because it introduces:
+
+- bulk operations
+- moderation or review workflows
+- audit/governance workflows
+- materially different state, data-access, or orchestration
+- operational dashboards that are more than guarded variants of the same reusable features
+
+### Default Approach
+
+Keep reusable capability artifacts in the domain library and let consuming apps decide whether they are public, authenticated, staff-only, or admin-only through:
+
+- route composition
+- guards and policies
+- page-level orchestration
+- backend authorization
+
+Reference: `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md`

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ If local dry-runs are needed, use the repo runner, for example `yarn nx run rele
 - Angular: `ui <- feature -> state -> data-access` | `config`, `util`: available to all layers
 - Nest: `presentation -> application <- infrastructure` | `config`, `util`: available to all layers
 - Shared TS: framework-agnostic DTOs/models/builders/utilities
+- Do not split libraries by audience (`admin`, `public`, `backoffice`, etc.) as a default rule; package by capability first and introduce audience-specific libraries only when workflow divergence is real.
 
 ## Library Consumption Conventions
 
@@ -167,6 +168,7 @@ If local dry-runs are needed, use the repo runner, for example `yarn nx run rele
 - Keep precedence consistent when both inputs exist: explicit overrides > config-derived values > hardcoded defaults.
 - Mail transport setup should be centralized once at app root via `@anarchitects/common-nest-mailer` (`CommonMailerModule.forRootFromConfig()` or `forRootAsync(...)`), while domain infrastructure-mailer entry points remain thin wrappers over shared provider wiring via `CommonMailerModule.forRoot(...)`.
 - Domain facade modules should expose mailer provider controls (for example `mailer.provider`) so infrastructure adapters can be composed per domain without changing root mail transport setup.
+- Audience and access policy are usually host-app composition concerns; prefer neutral, capability-focused library names and let consuming apps apply route guards, layouts, and page-level orchestration.
 
 ## Cross-Repo Alignment Position
 
@@ -189,6 +191,7 @@ Alignment does **not** mean identical file structure or forced architectural sam
 ## Architecture Decision Records
 
 - [ADR-0001: Align With `anarchitecture-bricks-ddd` And Support Migration](docs/adr/0001-align-with-bricks-ddd-and-support-migration.md)
+- [ADR-0002: Do Not Split Libraries By Audience Until Workflow Divergence Is Real](docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md)
 
 ## Documentation Tooling
 

--- a/docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md
+++ b/docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md
@@ -1,0 +1,129 @@
+# ADR-0002: Do Not Split Libraries By Audience Until Workflow Divergence Is Real
+
+- Status: Accepted
+- Date: 2026-04-23
+- Deciders: Anarchitects maintainers
+
+## Context
+
+This repository publishes reusable 3-tier domain libraries intended for consumption by multiple host applications.
+
+A recurring design question is whether features should be split into separate libraries based on audience, for example:
+
+- public vs admin
+- customer vs staff
+- portal vs backoffice
+
+A concrete example is `forms-angular`:
+
+- `form` supports building and rendering forms
+- `submission-list` and `submission-detail` support reading form submissions
+
+In one host application, submission-reading surfaces may live behind an admin or staff guard.
+In another host application, similar surfaces may be visible to end users, owners, or operators.
+
+If the repository encodes a specific audience into package boundaries too early, it risks:
+
+- coupling reusable capabilities to one deployment context
+- reducing reuse across consuming apps
+- turning access policy into a packaging concern
+- creating premature package proliferation
+- making migration and alignment with companion repos harder
+
+## Decision
+
+This repository will **not split libraries by audience as a default rule**.
+
+Instead, libraries should be organized primarily by:
+
+- domain capability
+- layer responsibility
+- orchestration/workflow surface
+- reusable technical concern
+
+Audience-specific packaging such as `*-admin`, `*-public`, or `*-backoffice` should be introduced **only when workflow divergence is real**, not merely because different routes or guards exist.
+
+## What Counts As Real Workflow Divergence
+
+A separate audience-specific library is justified when the admin or staff experience becomes a genuinely different capability surface, for example when it introduces one or more of the following:
+
+- bulk operations
+- moderation or review workflows
+- audit or governance workflows
+- internal-only commands or actions
+- materially different state, data-access, or orchestration needs
+- dashboards or operational workspaces that are not just guarded versions of the same reusable components
+
+A separate audience-specific library is **not** justified when the difference is primarily:
+
+- route location
+- route guard or policy
+- layout shell
+- host-app composition
+- whether a host app exposes the same capability to internal or external users
+
+## Consequences
+
+### Positive
+
+- reusable domain capabilities stay broadly consumable
+- access control remains a host-app composition concern
+- package boundaries better reflect reusable behavior
+- feature/UI libraries remain more portable across consuming apps
+- the repo stays aligned with its capability-first architecture
+
+### Trade-offs
+
+- consumers must compose audience-specific pages and route protection themselves
+- library naming must stay neutral and capability-focused
+- docs must clearly state that access policy is not implied by the library name
+
+## Guidance
+
+### Preferred approach
+
+Keep reusable capability artifacts in their domain library, for example within `forms-angular`:
+
+- `ui/form`
+- `ui/submission-list`
+- `ui/submission-detail`
+- `feature/form`
+- `feature/submission-list`
+- `feature/submission-detail`
+
+Then let the consuming app decide whether these surfaces are:
+
+- public
+- authenticated
+- staff-only
+- admin-only
+- owner-only
+
+using:
+
+- route composition
+- route guards or policies
+- page-level orchestration
+- backend authorization
+
+### Example
+
+`submission-list` and `submission-detail` should remain generic submission-reading capabilities unless they evolve into a materially different admin workflow.
+
+If a host app wants an admin page, it should usually compose one at the app level, for example:
+
+- `AdminFormSubmissionsPage`
+- `StaffSubmissionReviewPage`
+- `MySubmissionsPage`
+
+using the same reusable library capabilities underneath.
+
+### Escalation path
+
+Create a separate audience-specific library only when the consumer-facing and admin-facing workflow surfaces have diverged enough that sharing the same feature surface becomes confusing or constraining.
+
+## Rule
+
+**Do not split libraries by audience until workflow divergence is real.**
+
+Package by capability first. Treat audience and access policy as composition concerns unless they create a genuinely distinct workflow surface.

--- a/skills/bricks-3tier-implementation/SKILL.md
+++ b/skills/bricks-3tier-implementation/SKILL.md
@@ -13,6 +13,7 @@ Before changing code, inspect these repo files when relevant:
 - domain package `README.md` files
 - `docs/guides/alignment-with-bricks-ddd.md`
 - `docs/guides/migration-to-bricks-ddd.md`
+- `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md`
 
 ## Core implementation rules
 - Keep shared schemas, dto definitions, builders, and typed models in `libs/*/ts`.
@@ -23,6 +24,8 @@ Before changing code, inspect these repo files when relevant:
 - Keep examples as validation surfaces, not product packages.
 - Do not create or modify anything under `apps/`.
 - Do not manually edit generated OpenAPI artifacts under `docs/openapi/`.
+- Do not split libraries by audience (`admin`, `public`, `backoffice`, etc.) as a default rule; package by capability first and introduce audience-specific libraries only when workflow divergence is real.
+- If the difference is mainly route location, route guard, layout shell, or host-app composition, keep the reusable capability in the domain library and let the consuming app compose the audience-specific page.
 
 ## Required workflow
 1. Identify the target domain under `libs/<domain>`.
@@ -41,6 +44,7 @@ Before changing code, inspect these repo files when relevant:
 - Keep state intentionally scoped.
 - Do not introduce implicit root-scoped domain state.
 - Keep presentational concerns in `ui`, smart orchestration in `feature`, state in `state`, and transport in `data-access`.
+- Treat audience and access policy as composition concerns unless the admin or staff surface has become a genuinely different workflow.
 
 ## Cross-repo alignment check
 When the change affects domain meaning, public capability, package naming, or migration expectations, also inspect:
@@ -48,5 +52,6 @@ When the change affects domain meaning, public capability, package naming, or mi
 - `docs/guides/alignment-with-bricks-ddd.md`
 - `docs/guides/migration-to-bricks-ddd.md`
 - `docs/adr/0001-align-with-bricks-ddd-and-support-migration.md`
+- `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md`
 
 If the requested change would make future migration to the DDD repo harder, say so explicitly.

--- a/skills/monitor-ci/SKILL.md
+++ b/skills/monitor-ci/SKILL.md
@@ -12,6 +12,7 @@ Inspect these sources first when relevant:
 - `AGENTS.md`
 - `README.md`
 - the affected package `README.md`
+- `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md` when the failure is tied to package boundaries or library placement
 
 ## Required workflow
 1. Identify the failing workflow, job, and Nx target.
@@ -25,6 +26,7 @@ Inspect these sources first when relevant:
 - Respect the docs-surface and release workflow rules already documented in the repo.
 - Do not “fix” OpenAPI or docs failures by editing generated artifacts directly.
 - Do not bypass module boundaries or simplify architecture just to make CI green.
+- Do not move features into audience-specific libraries (`admin`, `public`, `backoffice`, etc.) as a quick fix unless there is genuine workflow divergence that justifies the split.
 - If a failure is tied to cross-repo alignment with `anarchitecture-bricks-ddd`, mention that explicitly.
 
 ## Output expectations


### PR DESCRIPTION
## Summary

Codify the repo rule that libraries should not be split by audience (`admin`, `public`, `backoffice`, etc.) until workflow divergence is real.

## Changed

- added ADR-0002:
  - `docs/adr/0002-do-not-split-libraries-by-audience-until-workflow-divergence-is-real.md`
- updated `README.md` to surface the new audience-vs-capability packaging rule and ADR
- updated `AGENTS.md` so repo agents apply the same rule consistently
- updated repo-local skills:
  - `skills/bricks-3tier-implementation/SKILL.md`
  - `skills/monitor-ci/SKILL.md`

## What this establishes

- package by capability first
- treat audience and access policy as consuming-app composition concerns by default
- introduce audience-specific libraries only when admin/staff/backoffice flows become genuinely different workflow surfaces
- keep reusable domain features such as `forms-angular` submission reading surfaces generic unless they evolve into materially different admin workflows

## Notes

This is a docs/ADR/agent-guidance change set only. It does not change runtime code or package structure.

## Rationale example

For `forms-angular`, `submission-list` and `submission-detail` should remain generic reusable capability surfaces unless they grow into clearly distinct admin/staff workflows with different orchestration, state, or operations.
